### PR TITLE
Avoid `unwrap()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,11 @@ table! {
 }
 
 fn users_with_name(connection: &Connection, target_name: &str)
-    -> Vec<(i32, String, Option<String>)>
+    -> QueryResult<Vec<(i32, String, Option<String>)>>
 {
     use self::users::dsl::*;
-    users.filter(name.eq(target_name))
-        .load(connection)
-        .unwrap()
-        .collect()
+    users.filter(name.eq(target_name)).load(connection)
+        .map(|x| x.collect())
 }
 ```
 
@@ -212,7 +210,7 @@ fn delete_user(connection: &Connection, user: User) -> QueryResult<()> {
     use diesel::query_builder::delete;
     use users::dsl::*;
 
-    delete(users.filter(id.eq(user.id))).execute(&connection).unwrap();
+    try!(delete(users.filter(id.eq(user.id))).execute(&connection));
     debug_assert!(deleted_rows == 1);
     Ok(())
 }

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -38,7 +38,7 @@ pub fn count<T: Expression>(t: T) -> Count<T> {
 /// # fn main() {
 /// #     use self::users::dsl::*;
 /// #     let connection = establish_connection();
-/// assert_eq!(Some(2), users.select(count_star()).first(&connection).unwrap());
+/// assert_eq!(Ok(Some(2)), users.select(count_star()).first(&connection));
 /// # }
 pub fn count_star() -> CountStar {
     CountStar

--- a/diesel/src/expression/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression/expression_methods/global_expression_methods.rs
@@ -43,7 +43,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// #     use self::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let data = users.select(id).filter(name.eq("Sean"));
-    /// assert_eq!(1, data.first(&connection).unwrap());
+    /// assert_eq!(Ok(1), data.first(&connection));
     /// # }
     /// ```
     fn eq<T: AsExpression<Self::SqlType>>(self, other: T) -> Eq<Self, T::Expression> {
@@ -69,7 +69,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// #     use self::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let data = users.select(id).filter(name.ne("Sean"));
-    /// assert_eq!(2, data.first(&connection).unwrap());
+    /// assert_eq!(Ok(2), data.first(&connection));
     /// # }
     /// ```
     fn ne<T: AsExpression<Self::SqlType>>(self, other: T) -> NotEq<Self, T::Expression> {

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -29,9 +29,9 @@ use super::IncompleteInsertStatement;
 /// #     let connection = establish_connection();
 /// let command = update(users.filter(id.eq(1)))
 ///     .set(name.eq("James"));
-/// let updated_row = connection.query_one(command).unwrap();
+/// let updated_row = connection.query_one(command);
 /// // When passed to `query_one`, the update statement will gain `RETURNING *`
-/// assert_eq!((1, "James".to_string()), updated_row);
+/// assert_eq!(Ok((1, "James".to_string())), updated_row);
 /// # }
 /// ```
 pub fn update<T: UpdateTarget>(source: T) -> IncompleteUpdateStatement<T> {
@@ -58,13 +58,18 @@ pub fn update<T: UpdateTarget>(source: T) -> IncompleteUpdateStatement<T> {
 /// # }
 /// #
 /// # fn main() {
+/// #     delete();
+/// # }
+/// #
+/// # fn delete() -> QueryResult<()> {
 /// #     use self::users::dsl::*;
 /// #     use diesel::query_builder::delete;
 /// #     let connection = establish_connection();
 /// #     let get_count = || users.count().first::<i64>(&connection).unwrap();
 /// let old_count = get_count();
-/// delete(users.filter(id.eq(1))).execute(&connection).unwrap();
+/// try!(delete(users.filter(id.eq(1))).execute(&connection));
 /// assert_eq!(old_count - 1, get_count());
+/// # Ok(())
 /// # }
 /// ```
 ///
@@ -82,12 +87,17 @@ pub fn update<T: UpdateTarget>(source: T) -> IncompleteUpdateStatement<T> {
 /// # }
 /// #
 /// # fn main() {
+/// #     delete();
+/// # }
+/// #
+/// # fn delete() -> QueryResult<()> {
 /// #     use self::users::dsl::*;
 /// #     use diesel::query_builder::delete;
 /// #     let connection = establish_connection();
 /// #     let get_count = || users.count().first::<i64>(&connection).unwrap();
-/// delete(users).execute(&connection).unwrap();
+/// try!(delete(users).execute(&connection));
 /// assert_eq!(0, get_count());
+/// # Ok(())
 /// # }
 /// ```
 pub fn delete<T: UpdateTarget>(source: T) -> DeleteStatement<T> {

--- a/diesel/src/query_dsl/filter_dsl.rs
+++ b/diesel/src/query_dsl/filter_dsl.rs
@@ -25,11 +25,11 @@ use types::Bool;
 /// #     use self::users::dsl::*;
 /// #     let connection = establish_connection();
 /// let seans_id = users.filter(name.eq("Sean")).select(id)
-///     .first(&connection).unwrap();
-/// assert_eq!(1, seans_id);
+///     .first(&connection);
+/// assert_eq!(Ok(1), seans_id);
 /// let tess_id = users.filter(name.eq("Tess")).select(id)
-///     .first(&connection).unwrap();
-/// assert_eq!(2, tess_id);
+///     .first(&connection);
+/// assert_eq!(Ok(2), tess_id);
 /// # }
 /// ```
 pub trait FilterDsl<Predicate: Expression<SqlType=Bool> + NonAggregate> {


### PR DESCRIPTION
This addresses https://github.com/sgrif/diesel/issues/34 partially.

There are a few cases that I wasn't sure how to handle:

* https://github.com/sgrif/diesel/blob/d2f5df84a29a293c1b99db7cb6dfa3f963520422/diesel/src/expression/array_comparison.rs#L34
* https://github.com/sgrif/diesel/blob/d2f5df84a29a293c1b99db7cb6dfa3f963520422/diesel/src/expression/extensions/interval_dsl.rs#L31-L41
* https://github.com/sgrif/diesel/blob/d2f5df84a29a293c1b99db7cb6dfa3f963520422/diesel/src/expression/extensions/interval_dsl.rs#L122-L132

It seems to me that in those cases one could return an empty iterator.

I was also unsure whether I could really ignore the result of delete statement executions. That's one reason I put those changes in a separate commit.

If nothing else, this pull request locates occurrences of `unwrap()` in the current documentation.