### PR TITLE
Debug sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## Unreleased
+
+### Added
+
+* Add DebugQueryBuilder to build sql without requiring a connection.
+
+* Add print_sql! and debug_sql! macros to print out and return sql strings from
+  QueryFragments.
+
 ## [0.3.0] 2015-12-04
 
 ### Changed

--- a/diesel/src/macros.rs
+++ b/diesel/src/macros.rs
@@ -346,3 +346,53 @@ macro_rules! join_through {
         }
     }
 }
+
+/// Takes a query QueryFragment expression as an argument and returns a string
+/// of SQL with placeholders for the dynamic values.
+///
+/// # Example
+///
+/// ### Returning SQL from a count statment:
+/// #
+/// # ```rust
+/// # // example requires setup for users table
+/// # use diesel::users::dsl::*;
+/// # use diesel::query_builder::QueryFragment;
+/// #
+/// # fn main() {
+/// let sql = debug_sql!(users.count());
+/// assert_eq!(sql, "SELECT COUNT(*) FROM users");
+/// # }
+/// # ```
+#[macro_export]
+macro_rules! debug_sql {
+    ($query:expr) => {{
+        use diesel::query_builder::QueryFragment;
+        let mut query_builder = DebugQueryBuilder::new();
+        QueryFragment::to_sql(&$query, &mut query_builder).unwrap();
+        query_builder.sql
+    }};
+}
+
+/// Takes takes a query QueryFragment expression as an argument and prints out
+/// the SQL with placeholders for the dynamic values.
+///
+/// # Example
+///
+/// ### Printing SQL from a count statment:
+/// #
+/// # ```rust
+/// # // example requires setup for users table
+/// # use diesel::users::dsl::*;
+/// # use diesel::query_builder::QueryFragment;
+/// #
+/// # fn main() {
+/// print_sql!(users.count());
+/// # }
+/// # ```
+#[macro_export]
+macro_rules! print_sql {
+    ($query:expr) => {
+        println!("{}", &debug_sql!($query));
+    };
+}

--- a/diesel/src/query_builder/debug.rs
+++ b/diesel/src/query_builder/debug.rs
@@ -1,0 +1,35 @@
+use super::{QueryBuilder, BuildQueryResult};
+use types::NativeSqlType;
+
+#[doc(hidden)]
+pub struct DebugQueryBuilder {
+    pub sql: String,
+    pub bind_types: Vec<u32>,
+    bind_idx: u32,
+}
+
+impl DebugQueryBuilder {
+    pub fn new() -> Self {
+        DebugQueryBuilder {
+            sql: String::new(),
+            bind_types: Vec::new(),
+            bind_idx: 0,
+        }
+    }
+}
+
+impl QueryBuilder for DebugQueryBuilder {
+    fn push_sql(&mut self, sql: &str) {
+        self.sql.push_str(sql);
+    }
+
+    fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult {
+        Ok(self.push_sql(&identifier))
+    }
+
+    fn push_bound_value(&mut self, _tpe: &NativeSqlType, _bind: Option<Vec<u8>>) {
+        self.bind_idx += 1;
+        let sql = format!("${}", self.bind_idx);
+        self.push_sql(&sql);
+    }
+}

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -1,6 +1,7 @@
 //! Contains traits responsible for the actual construction of SQL statements
 #[doc(hidden)]
 pub mod pg;
+pub mod debug;
 
 mod delete_statement;
 mod functions;

--- a/diesel_tests/tests/debug/mod.rs
+++ b/diesel_tests/tests/debug/mod.rs
@@ -1,0 +1,17 @@
+use diesel::*;
+use diesel::query_builder::debug::DebugQueryBuilder;
+use diesel::query_builder::update;
+
+#[test]
+fn test_debug_count_output() {
+    use schema::users::dsl::*;
+    let sql = debug_sql!(users.count());
+    assert_eq!(sql, "SELECT COUNT(*) FROM users");
+}
+
+#[test]
+fn test_debug_output() {
+    use schema::users::dsl::*;
+    let command = update(users.filter(id.eq(1))).set(name.eq("new_name"));
+    assert_eq!(debug_sql!(command), "UPDATE users SET name = $1 WHERE users.id = $2")
+}

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -24,3 +24,4 @@ mod select;
 mod transactions;
 mod types;
 mod types_roundtrip;
+mod debug;


### PR DESCRIPTION
This PR adds DebugQueryBuilder which can be used to build SQL from a QueryFragment without the need for a connection.  It also adds a printsql! macro that uses the debug query builder.

The output at the moment is using placeholders for the dynamic parts of the sql.
```
let command = update(users.filter(id.eq(1))).set(name.eq("new_name"));
printsql!(command);
```
```
"UPDATE users SET name = $1 WHERE users.id = $2"
```

Closes #41 