### PR TITLE
`#[changeset_for]` now skips optional fields when `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
+### Changed
+
+* `#[changeset_for(table)]` now treats `Option` fields as an optional update.
+  Previously a field with `None` for the value would insert `NULL` into the
+  database field. It now does not update the field if the value is `None`.
+
 ### Fixed
 
 * `#[derive(Queriable)]` now allows generic parameters on the struct.

--- a/diesel/src/expression/predicates.rs
+++ b/diesel/src/expression/predicates.rs
@@ -149,6 +149,10 @@ impl<T, U> Changeset for Eq<T, U> where
 {
     type Target = T::Table;
 
+    fn is_noop(&self) -> bool {
+        false
+    }
+
     fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
         try!(out.push_identifier(T::name()));
         out.push_sql(" = ");

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -123,12 +123,21 @@ macro_rules! tuple_impls {
             {
                 type Target = Target;
 
+                fn is_noop(&self) -> bool {
+                    $(e!(self.$idx.is_noop()) &&)+ true
+                }
+
                 fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+                    let noop_element = true;
                     $(
-                        if e!($idx) != 0 {
-                            out.push_sql(", ");
+                        let needs_comma = !noop_element;
+                        let noop_element = e!(self.$idx.is_noop());
+                        if !noop_element {
+                            if needs_comma {
+                                out.push_sql(", ");
+                            }
+                            try!(e!(self.$idx.to_sql(out)));
                         }
-                        try!(e!(self.$idx.to_sql(out)));
                     )+
                     Ok(())
                 }

--- a/diesel_codegen/README.md
+++ b/diesel_codegen/README.md
@@ -102,11 +102,16 @@ additional configurations.
 Adds an implementation of the [`AsChangeset`][as_changeset] trait to the
 annotated item, targeting the given table. At this time, it only supports
 structs with named fields. Tuple structs and enums are not supported. See [field
-annotations][#field-annotations] for additional configurations. If the struct
-has a field for the primary key, an additional function, `save_changes(&mut
-self, connection: &Connection) -> QueryResult<()>`, will be added to the model.
-This will persist the model to the database and update it with any fields the
-database returns.
+annotations][#field-annotations] for additional configurations.
+
+Any fields which are of the type `Option` will be skipped when their value is
+`None`. This makes it easy to support APIs where you may not want to update all
+of the fields of a record on every request.
+
+If the struct has a field for the primary key, an additional function,
+`save_changes(&mut self, connection: &Connection) -> QueryResult<()>`, will be
+added to the model.  This will persist the model to the database and update it
+with any fields the database returns.
 
 [queriable]: http://sgrif.github.io/diesel/diesel/query_source/trait.Queriable.html
 [insertable]: http://sgrif.github.io/diesel/diesel/trait.Insertable.html

--- a/diesel_tests/tests/lib.in.rs
+++ b/diesel_tests/tests/lib.in.rs
@@ -1,3 +1,4 @@
 mod schema;
 mod insert;
 mod deserialization;
+mod update;

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -24,4 +24,3 @@ mod select;
 mod transactions;
 mod types;
 mod types_roundtrip;
-mod update;


### PR DESCRIPTION
My original thoughts on how to implement this involved boxing and
sticking in a `Vec`. Unfortunately, that requires implementing
`AsChangeset` for `UserChanges` and not `&UserChanges`, which I don't
want to do by default.

If you actually want to assign `NULL`, you can still do so by doing
`update(table).set(column.eq(None))`. In the future we might introduce
an additional type to make it possible to assign null through codegen.

With this change in implementation, I've removed the impl of `Changeset`
for `Vec<T>`, as it feels redundant with a tuple containing options.

I've done a best effort to make sure we generate valid SQL in the
various cases. There is still one error case, when the resulting
changeset has 0 fields to update. This will be corrected in another PR,
as I'm still considering whether we should do magic to return the same
thing as we would otherwise, or whether it's an error case.

Fixes #26