### PR TITLE
First pass at schema inference

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,1 +1,2 @@
-DATABASE_URL=postgresql://localhost/yaqb_test
+DATABASE_URL=postgresql://localhost/diesel_test
+DATABASE_URL_FOR_SCHEMA=postgresql://localhost/diesel_schema

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ rust:
 addons:
   postgresql: '9.4'
 before_script:
-- |
-  pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:$PATH
+  - pip install 'travis-cargo<0.2' --user
+  - export PATH=$HOME/.local/bin:$PATH
+  - psql -c 'create database diesel_schema;' -U postgres
 script:
 - |
   (cd diesel && travis-cargo build) &&
@@ -21,10 +21,10 @@ script:
     (cd diesel_tests && travis-cargo test)
   fi
 env:
-  matrix:
-  - DATABASE_URL=postgres://postgres@localhost/
   global:
-    secure: NmCM1VNEzid6bROA7tXV1R63n9S9KvY1etXsDzd1608cvjRnG3ZDAWXISbY1BxqrvleElreUJOvz/3TSQCHivpT2ezeyk2sntYtZpw0TWbz1SQMAPNWPTjP3bNQzpmNwfU4p6ui6qIOnQza4JxOu3SZSveNlehDBPkkS+52R7Zw/EPdwi9jTYJArV2+8pnEsQECAdRLttbtA2JBl3hZ4VHfGpHRZyeULn63UzyVbQVzQ3NVhqyQUKTPdpUciQTI3fZEkfaWuLV8QPPa5026/yJEEi2Fsl3r7fyY8ia67k4Zo9THlPVD0YOUlkWuZWwvkxNA8RQSVPv4FidEpwbxG8y6nAra4CjwiEChcpFhZJtrH7ZrXO/tJk7vtc5CFVWUsQtNX92QY1QFdPxwYNBSICLyUN+A+BQURwvQgxdcJsJyQmh5Ed7yuavcAinVq7fPeOyBWcPL5mt17no16aG1rzvXSUnD0aH7F3S3DHkoM9P9iHgJMLk+2YNmJtFescBxCeG8bA7t5bw0kQNH5KUWAD1uYpC9ikB3NVdlc+q17dKTAe4rcYA+sIO+UGudvpmLWT0lXtEMqDfxfCmyICDESs9bNfueCGJEAnfTBNunsJqR7rMUvjNndS2/Ssok6c/0Yfb9X8cM9nI4QLAj/+hClqdYphmpCjuC34bWxFSt/KJI=
+    - DATABASE_URL=postgres://postgres@localhost/
+    - DATABASE_URL_FOR_SCHEMA=postgres://postgres@localhost/diesel_schema
+    - secure: NmCM1VNEzid6bROA7tXV1R63n9S9KvY1etXsDzd1608cvjRnG3ZDAWXISbY1BxqrvleElreUJOvz/3TSQCHivpT2ezeyk2sntYtZpw0TWbz1SQMAPNWPTjP3bNQzpmNwfU4p6ui6qIOnQza4JxOu3SZSveNlehDBPkkS+52R7Zw/EPdwi9jTYJArV2+8pnEsQECAdRLttbtA2JBl3hZ4VHfGpHRZyeULn63UzyVbQVzQ3NVhqyQUKTPdpUciQTI3fZEkfaWuLV8QPPa5026/yJEEi2Fsl3r7fyY8ia67k4Zo9THlPVD0YOUlkWuZWwvkxNA8RQSVPv4FidEpwbxG8y6nAra4CjwiEChcpFhZJtrH7ZrXO/tJk7vtc5CFVWUsQtNX92QY1QFdPxwYNBSICLyUN+A+BQURwvQgxdcJsJyQmh5Ed7yuavcAinVq7fPeOyBWcPL5mt17no16aG1rzvXSUnD0aH7F3S3DHkoM9P9iHgJMLk+2YNmJtFescBxCeG8bA7t5bw0kQNH5KUWAD1uYpC9ikB3NVdlc+q17dKTAe4rcYA+sIO+UGudvpmLWT0lXtEMqDfxfCmyICDESs9bNfueCGJEAnfTBNunsJqR7rMUvjNndS2/Ssok6c/0Yfb9X8cM9nI4QLAj/+hClqdYphmpCjuC34bWxFSt/KJI=
 after_success:
 - "(cd diesel && travis-cargo --only nightly doc-upload)"
 branches:

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -29,16 +29,22 @@ pub type Serial = Integer;
 pub type BigSerial = BigInt;
 
 #[derive(Clone, Copy, Default)] pub struct SmallInt;
+#[doc(hidden)] pub type Int2 = SmallInt;
 #[derive(Clone, Copy, Default)] pub struct Integer;
+#[doc(hidden)] pub type Int4 = Integer;
 #[derive(Clone, Copy, Default)] pub struct BigInt;
+#[doc(hidden)] pub type Int8 = BigInt;
 
 #[derive(Clone, Copy, Default)] pub struct Float;
+#[doc(hidden)] pub type Float4 = Float;
 #[derive(Clone, Copy, Default)] pub struct Double;
+#[doc(hidden)] pub type Float8 = Double;
 #[derive(Clone, Copy, Default)] pub struct Numeric;
 
 #[derive(Clone, Copy, Default)] pub struct Oid;
 
 #[derive(Clone, Copy, Default)] pub struct VarChar;
+#[doc(hidden)] pub type Varchar = VarChar;
 #[derive(Clone, Copy, Default)] pub struct Text;
 
 #[derive(Clone, Copy, Default)] pub struct Binary;

--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -20,6 +20,7 @@ quasi = { verision = "^0.3.8", default-features = false }
 quasi_macros = { version = "^0.3.9", optional = true}
 syntex = { version = "^0.22.0", optional = true }
 syntex_syntax = { version = "^0.22.0", optional = true }
+diesel = { path = "../diesel" }
 
 [features]
 default = ["with-syntex"]

--- a/diesel_codegen/src/lib.in.rs
+++ b/diesel_codegen/src/lib.in.rs
@@ -3,4 +3,5 @@ mod attr;
 mod insertable;
 mod model;
 mod queriable;
+mod schema_inference;
 mod update;

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -4,6 +4,7 @@
 
 extern crate aster;
 extern crate quasi;
+#[macro_use] extern crate diesel;
 
 #[cfg(feature = "with-syntex")]
 extern crate syntex;
@@ -33,6 +34,7 @@ pub fn register(reg: &mut syntex::Registry) {
     reg.add_decorator("changeset_for", update::expand_changeset_for);
     reg.add_decorator("has_many", associations::expand_has_many);
     reg.add_decorator("belongs_to", associations::expand_belongs_to);
+    reg.add_macro("load_table_from_schema", schema_inference::expand_load_table);
 }
 
 #[cfg_attr(not(feature = "with-syntex"), plugin_registrar)]
@@ -60,4 +62,5 @@ pub fn register(reg: &mut rustc_plugin::Registry) {
         intern("belongs_to"),
         MultiDecorator(Box::new(associations::expand_belongs_to))
     );
+    reg.register_macro("load_table_from_schema", schema_inference::expand_load_table);
 }

--- a/diesel_codegen/src/schema_inference/data_structures.rs
+++ b/diesel_codegen/src/schema_inference/data_structures.rs
@@ -1,0 +1,53 @@
+use diesel::*;
+use diesel::types::{NativeSqlType, FromSqlRow};
+
+table! {
+    pg_attribute (attrelid) {
+        attrelid -> Oid,
+        attname -> VarChar,
+        atttypid -> Oid,
+        attnotnull -> Bool,
+        attnum -> SmallInt,
+        attisdropped -> Bool,
+    }
+}
+
+table! {
+    pg_type (oid) {
+        oid -> Oid,
+        typname -> VarChar,
+    }
+}
+
+joinable!(pg_attribute -> pg_type (atttypid = oid));
+select_column_workaround!(pg_attribute -> pg_type (attrelid, attname, atttypid, attnotnull, attnum, attisdropped));
+select_column_workaround!(pg_type -> pg_attribute (oid, typname));
+
+table! {
+    pg_class (oid) {
+        oid -> Oid,
+        relname -> VarChar,
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PgAttr {
+    pub column_name: String,
+    pub type_name: String,
+    pub nullable: bool,
+}
+
+impl<ST> Queriable<ST> for PgAttr where
+    ST: NativeSqlType,
+    (String, String, bool): FromSqlRow<ST>,
+{
+    type Row = (String, String, bool);
+
+    fn build(row: Self::Row) -> Self {
+        PgAttr {
+            column_name: row.0,
+            type_name: row.1,
+            nullable: !row.2,
+        }
+    }
+}

--- a/diesel_codegen/src/schema_inference/mod.rs
+++ b/diesel_codegen/src/schema_inference/mod.rs
@@ -1,0 +1,111 @@
+mod data_structures;
+
+use diesel::*;
+use syntax::ast;
+use syntax::codemap::Span;
+use syntax::ext::base::*;
+use syntax::parse::token::{InternedString, str_to_ident};
+use syntax::ptr::P;
+use syntax::util::small_vector::SmallVector;
+
+use self::data_structures::*;
+
+pub fn expand_load_table<'cx>(
+    cx: &'cx mut ExtCtxt,
+    sp: Span,
+    tts: &[ast::TokenTree]
+) -> Box<MacResult+'cx> {
+    let mut exprs = match get_exprs_from_tts(cx, sp, tts) {
+        Some(ref exprs) if exprs.is_empty() => {
+            cx.span_err(sp, "load_table_from_schema! takes 2 arguments");
+            return DummyResult::any(sp);
+        }
+        None => return DummyResult::any(sp),
+        Some(exprs) => exprs.into_iter()
+    };
+
+    match load_table_body(cx, sp, &mut exprs) {
+        Ok(res) => res,
+        Err(res) => res,
+    }
+}
+
+pub fn load_table_body<T: Iterator<Item=P<ast::Expr>>>(
+    cx: &mut ExtCtxt,
+    sp: Span,
+    exprs: &mut T,
+) -> Result<Box<MacResult>, Box<MacResult>> {
+    let database_url = try!(next_str_lit(cx, sp, exprs));
+    let table_name = try!(next_str_lit(cx, sp, exprs));
+
+    let connection = try!(Connection::establish(&database_url).map_err(|_| {
+        cx.span_err(sp, "failed to establish a database connection");
+        DummyResult::any(sp)
+    }));
+
+    match get_table_data(&connection, &table_name) {
+        Err(NotFound) => {
+            cx.span_err(sp, &format!("no table exists named {}", &table_name));
+            Err(DummyResult::any(sp))
+        }
+        Err(_) => {
+            cx.span_err(sp, "error loading schema");
+            Err(DummyResult::any(sp))
+        }
+        Ok(data) => {
+            let tokens = data.iter().map(|a| column_def_tokens(cx, a))
+                .collect::<Vec<_>>();
+            let table_name = str_to_ident(&table_name);
+            let item = quote_item!(cx, table! {
+                $table_name {
+                    $tokens
+                }
+            }).unwrap();
+            Ok(MacEager::items(SmallVector::one(item)))
+        }
+    }
+}
+
+fn next_str_lit<T: Iterator<Item=P<ast::Expr>>>(
+    cx: &mut ExtCtxt,
+    sp: Span,
+    exprs: &mut T,
+) -> Result<InternedString, Box<MacResult>> {
+    match expr_to_string(cx, exprs.next().unwrap(), "expected string literal") {
+        Some((s, _)) => Ok(s),
+        None => Err(DummyResult::any(sp)),
+    }
+}
+
+fn get_table_data(conn: &Connection, table_name: &str) -> QueryResult<Vec<PgAttr>> {
+    use self::data_structures::pg_attribute::dsl::*;
+    use self::data_structures::pg_type::dsl::{pg_type, typname};
+    let t_oid = try!(table_oid(conn, table_name));
+
+    pg_attribute.inner_join(pg_type)
+        .select((attname, typname, attnotnull))
+        .filter(attrelid.eq(t_oid))
+        .filter(attnum.gt(0).and(attisdropped.ne(true)))
+        .order(attnum)
+        .load(&conn)
+        .map(|r| r.collect::<Vec<_>>())
+}
+
+fn table_oid(conn: &Connection, table_name: &str) -> QueryResult<u32> {
+    use self::data_structures::pg_class::dsl::*;
+    pg_class.select(oid).filter(relname.eq(table_name)).first(&conn)
+}
+
+fn column_def_tokens(cx: &mut ExtCtxt, attr: &PgAttr) -> Vec<ast::TokenTree> {
+    let column_name = str_to_ident(&attr.column_name);
+    let type_name = str_to_ident(&capitalize(&attr.type_name));
+    if attr.nullable {
+        quote_tokens!(cx, $column_name -> Nullable<$type_name>,)
+    } else {
+        quote_tokens!(cx, $column_name -> $type_name,)
+    }
+}
+
+fn capitalize(name: &str) -> String {
+    name[..1].to_uppercase() + &name[1..]
+}

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -9,6 +9,8 @@ build = "build.rs"
 syntex = { version = "^0.22.0", optional = true }
 diesel_codegen = { path = "../diesel_codegen", default-features = false }
 dotenv_codegen = { version = "^0.7.0", optional = true }
+diesel = { path = "../diesel" }
+dotenv = "^0.7.0"
 
 [dependencies]
 diesel = { path = "../diesel", features = ["quickcheck"] }

--- a/diesel_tests/build.rs
+++ b/diesel_tests/build.rs
@@ -25,6 +25,40 @@ mod inner {
     pub fn main() {}
 }
 
+extern crate diesel;
+extern crate dotenv;
+use diesel::*;
+use dotenv::dotenv;
+
 fn main() {
+    dotenv().ok();
+    let database_url = ::std::env::var("DATABASE_URL_FOR_SCHEMA")
+        .expect("DATABASE_URL_FOR_SCHEMA must be set and different \
+                from DATABASE_URL for integration tests, so we can \
+                test our schema inference code.");
+    let connection = Connection::establish(&database_url).unwrap();
+    setup_tables_for_schema(&connection);
     inner::main();
+}
+
+fn setup_tables_for_schema(connection: &Connection) {
+    connection.execute("DROP TABLE IF EXISTS users").unwrap();
+    connection.execute("DROP TABLE IF EXISTS posts").unwrap();
+    connection.execute("DROP TABLE IF EXISTS comments").unwrap();
+    connection.execute("CREATE TABLE users (
+        id SERIAL PRIMARY KEY,
+        name VARCHAR NOT NULL,
+        hair_color VARCHAR
+    )").unwrap();
+    connection.execute("CREATE TABLE posts (
+        id SERIAL PRIMARY KEY,
+        user_id INTEGER NOT NULL,
+        title VARCHAR NOT NULL,
+        body TEXT
+    )").unwrap();
+    connection.execute("CREATE TABLE comments (
+        id SERIAL PRIMARY KEY,
+        post_id INTEGER NOT NULL,
+        text TEXT NOT NULL
+    )").unwrap();
 }

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -57,32 +57,10 @@ pub struct Comment {
     text: String,
 }
 
-// Compiler plugin will automatically invoke this based on schema
-table! {
-    users {
-        id -> Serial,
-        name -> VarChar,
-        hair_color -> Nullable<VarChar>,
-    }
-}
+load_table_from_schema!(dotenv!("DATABASE_URL_FOR_SCHEMA"), "users");
+load_table_from_schema!(dotenv!("DATABASE_URL_FOR_SCHEMA"), "posts");
+load_table_from_schema!(dotenv!("DATABASE_URL_FOR_SCHEMA"), "comments");
 numeric_expr!(users::id);
-
-table! {
-    posts {
-        id -> Serial,
-        user_id -> Integer,
-        title -> VarChar,
-        body -> Nullable<Text>,
-    }
-}
-
-table! {
-    comments {
-        id -> Serial,
-        post_id -> Integer,
-        text -> Text,
-    }
-}
 
 select_column_workaround!(users -> comments (id, name, hair_color));
 select_column_workaround!(comments -> users (id, post_id, text));


### PR DESCRIPTION
This macro takes a database connection at compile time, inquires about
the schema, and invoke the `table!` macro for you automatically. This is
an early pass, and it doesn't support any types from third party crates,
or custom primary keys (I'm not even 100% sure that it won't error some
of the time on types that we do support).

Right now we're going off of the type name and capitalizing it to find
the right type. I'm unsure if we'd be better off using the OID (and then
the aliases would be `Oid6342 = Array<Json>` or whatever). We do need to
decide that before 1.0, as it'll be a breaking change for third party
crates.

I've had to do some funkiness in our tests, where basically I set up the
schema on a separate database from where our tests run. This is because
our suite assumes that we can rely on the id 1, which means the table
has to be created in that test. I cannot drop the tables before the
tests run, because on nightly I don't have a place to execute code after
compilation finishes.

As such, this doesn't actually make our tests look much cleaner, but
once we refactor to work w/ persistenct schema we should be able to
remove a lot of code.