### PR TITLE
Refactor test suite to not use hardcoded IDs

### DIFF
--- a/diesel_tests/tests/associations.rs
+++ b/diesel_tests/tests/associations.rs
@@ -6,8 +6,8 @@ fn one_to_many_returns_query_source_for_association() {
     let connection = connection_with_sean_and_tess_in_users_table();
     setup_posts_table(&connection);
 
-    let sean: User = connection.find(users::table, 1).unwrap();
-    let tess: User = connection.find(users::table, 2).unwrap();
+    let sean = find_user_by_name("Sean", &connection);
+    let tess = find_user_by_name("Tess", &connection);
     let seans_posts: Vec<Post> =  insert(&vec![
         sean.new_post("Hello", None), sean.new_post("World", None)
         ]).into(posts::table)

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -6,12 +6,15 @@ fn filter_by_int_equality() {
     use schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
+    let sean_id = find_user_by_name("Sean", &connection).id;
+    let tess_id = find_user_by_name("Tess", &connection).id;
+    let unused_id = sean_id + tess_id;
 
-    let sean = User::new(1, "Sean");
-    let tess = User::new(2, "Tess");
-    assert_eq!(Ok(sean), users.filter(id.eq(1)).first(&connection));
-    assert_eq!(Ok(tess), users.filter(id.eq(2)).first(&connection));
-    assert_eq!(Err(NotFound), users.filter(id.eq(3)).first::<User>(&connection));
+    let sean = User::new(sean_id, "Sean");
+    let tess = User::new(tess_id, "Tess");
+    assert_eq!(Ok(sean), users.filter(id.eq(sean_id)).first(&connection));
+    assert_eq!(Ok(tess), users.filter(id.eq(tess_id)).first(&connection));
+    assert_eq!(Err(NotFound), users.filter(id.eq(unused_id)).first::<User>(&connection));
 }
 
 #[test]

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -151,3 +151,10 @@ pub fn connection_with_sean_and_tess_in_users_table() -> Connection {
     insert(data).into(users::table).execute(&connection).unwrap();
     connection
 }
+
+pub fn find_user_by_name(name: &str, connection: &Connection) -> User {
+    let result: QueryResult<Vec<User>> = users::table.filter(users::name.eq(name))
+        .load(connection)
+        .map(|x| x.collect());
+    result.unwrap()[0].to_owned()
+}


### PR DESCRIPTION
Instead of relying on the 'Sean' and 'Tess' users to be ids 1 and 2
respectively, find the users by their names.

Resolves #48