### PR TITLE
Build on the latest nightly again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 rust:
   - stable
   - beta
-  - nightly-2015-12-03
+  - nightly-2015-12-08
   - nightly
 addons:
   postgresql: '9.4'

--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -11,15 +11,15 @@ repository = "https://github.com/sgrif/diesel/tree/master/diesel_codegen"
 keywords = ["orm", "database", "postgres", "sql", "codegen"]
 
 [build-dependencies]
-quasi_codegen = { verision = "^0.3.8", optional = true }
+quasi_codegen = { verision = "^0.3.10", optional = true }
 syntex = { version = "^0.22.0", optional = true }
 
 [dependencies]
-aster = { version = "^0.8.0", default-features = false }
-quasi = { verision = "^0.3.8", default-features = false }
-quasi_macros = { version = "^0.3.9", optional = true}
+aster = { version = "^0.9.0", default-features = false }
+quasi = { verision = "^0.3.10", default-features = false }
+quasi_macros = { version = "^0.3.10", optional = true}
 syntex = { version = "^0.22.0", optional = true }
-syntex_syntax = { version = "^0.22.0", optional = true }
+syntex_syntax = { version = "^0.23.0", optional = true }
 diesel = { version = "^0.3.0" }
 
 [features]

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 [build-dependencies]
 syntex = { version = "^0.22.0", optional = true }
 diesel_codegen = { path = "../diesel_codegen", default-features = false }
-dotenv_codegen = { version = "^0.7.0", optional = true }
+dotenv_codegen = { git = "https://github.com/mcasper/rust-dotenv", rev = "a12e8e097681ef5a398c652f8ff6f041502cd729",  optional = true }
 diesel = { path = "../diesel" }
 dotenv = "^0.7.0"
 


### PR DESCRIPTION
Updates various dependencies affected by
https://github.com/rust-lang/rust/pull/29850.

Opening so that other people won't have to duplicate this work, once
https://github.com/slapresta/rust-dotenv/pull/27 is merged I'll update
the dependency and this can go in.