### PR TITLE
Point back at released version of rust-dotenv.

### DIFF
--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -8,15 +8,15 @@ build = "build.rs"
 [build-dependencies]
 syntex = { version = "^0.22.0", optional = true }
 diesel_codegen = { path = "../diesel_codegen", default-features = false }
-dotenv_codegen = { git = "https://github.com/slapresta/rust-dotenv",  optional = true }
+dotenv_codegen = { version = "^0.7.1",  optional = true }
 diesel = { path = "../diesel" }
-dotenv = "^0.7.0"
+dotenv = "^0.7.1"
 
 [dependencies]
 diesel = { path = "../diesel", features = ["quickcheck"] }
 diesel_codegen = { path = "../diesel_codegen", default-features = false }
 compiletest_rs = { version = "^0.0.10", optional = true }
-dotenv_macros = { version = "^0.7.0", optional = true }
+dotenv_macros = { version = "^0.7.1", optional = true }
 
 [dev-dependencies]
 quickcheck = { git = "https://github.com/BurntSushi/quickcheck.git" }


### PR DESCRIPTION
Rust-dotenv published the patch from last night, so we can point at
0.7.1