### PR TITLE
Update quasi* to 0.3.11 to fix latest nightly build

### DIFF
--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -11,13 +11,13 @@ repository = "https://github.com/sgrif/diesel/tree/master/diesel_codegen"
 keywords = ["orm", "database", "postgres", "sql", "codegen"]
 
 [build-dependencies]
-quasi_codegen = { verision = "^0.3.10", optional = true }
+quasi_codegen = { verision = "^0.3.11", optional = true }
 syntex = { version = "^0.24.0", optional = true }
 
 [dependencies]
 aster = { version = "^0.9.0", default-features = false }
-quasi = { verision = "^0.3.10", default-features = false }
-quasi_macros = { version = "^0.3.10", optional = true}
+quasi = { verision = "^0.3.11", default-features = false }
+quasi_macros = { version = "^0.3.11", optional = true}
 syntex = { version = "^0.24.0", optional = true }
 syntex_syntax = { version = "^0.24.0", optional = true }
 diesel = { version = "^0.3.0" }


### PR DESCRIPTION
Quasi 0.3.10 is broken on the latest nightly because of
https://github.com/rust-lang/rust/pull/30460, 0.3.11 fixes the issues
and builds successfully.

@mcasper and @mikeastock