### PR TITLE
Fix a typo in the migrations module documentation

### DIFF
--- a/diesel/src/migrations/mod.rs
+++ b/diesel/src/migrations/mod.rs
@@ -6,7 +6,7 @@
 //! idempotent, as Diesel will ensure no migration is run twice unless it has been reverted.
 //!
 //! Migrations should be placed in a `/migrations` directory at the root of your project (the same
-//! directiry as `Cargo.toml`). When any of these functions are run, Diesel will search for the
+//! directory as `Cargo.toml`). When any of these functions are run, Diesel will search for the
 //! migrations directory in the current directory and its parents, stopping when it finds the
 //! directory containing `Cargo.toml`.
 //!


### PR DESCRIPTION
I don’t know if it is entirely appropriate to open a pull request for a single char typo in documentation (I am a very novice developer), but here it is.