### PR TITLE
[WIP] Add support for `chrono` types

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -14,6 +14,7 @@ libc = "0.2.*"
 pq-sys = "0.2.*"
 byteorder = "0.3.*"
 quickcheck = { git = "https://github.com/BurntSushi/quickcheck.git", optional = true }
+chrono = { version = "0.2.17", optional = true }
 
 [dev-dependencies]
 quickcheck = { git = "https://github.com/BurntSushi/quickcheck.git" }

--- a/diesel/src/types/impls/date_and_time/chrono.rs
+++ b/diesel/src/types/impls/date_and_time/chrono.rs
@@ -104,10 +104,12 @@ fn utc_datetime_to_sql() {
     ToSql::<Timestamp>::to_sql(&UTC.ymd(2000, 1, 1).and_hms(0, 0, 0), &mut bytes).unwrap();
     ToSql::<Timestamp>::to_sql(&UTC.ymd(2010, 12, 4).and_hms(14, 39, 6), &mut bytes).unwrap();
     ToSql::<Timestamp>::to_sql(&UTC.ymd(2032, 2, 4).and_hms(12, 59, 59), &mut bytes).unwrap();
+    ToSql::<Timestamp>::to_sql(&UTC.ymd(1789, 7, 14).and_hms(17, 30, 22), &mut bytes).unwrap();
     assert_eq!(bytes,
                vec![
                0,0,0,0,0,0,0,0,
                0x00,0x01,0x39,0x95,0x62,0xba,0x56,0x80,
                0x00,0x03,0x99,0x29,0x4d,0x41,0xd1,0xc0,
+               0xff,0xe8,0x67,0x82,0x01,0x2b,0xc7,0x80,
                ]);
 }

--- a/diesel/src/types/impls/date_and_time/chrono.rs
+++ b/diesel/src/types/impls/date_and_time/chrono.rs
@@ -1,0 +1,127 @@
+//! This module makes it possible to map `chrono::DateTime` values to postgres `Date`
+//! and `Timestamp` fields. It is enabled with the `chrono` feature.
+
+extern crate chrono;
+extern crate byteorder as localbyteorder; // conflicts otherwise
+
+use std::fmt::Display;
+use std::error::Error;
+use std::io::Write;
+use self::localbyteorder::{ReadBytesExt, WriteBytesExt, BigEndian};
+use self::chrono::{Duration, NaiveDate, NaiveDateTime, DateTime, UTC, Local, FixedOffset, TimeZone};
+
+use expression::{Expression, NonAggregate};
+use query_builder::{QueryBuilder, BuildQueryResult};
+use types::{FromSql, IsNull, Timestamp, ToSql};
+
+
+// Postgres timestamps start from January 1st 2000.
+fn base() -> NaiveDateTime {
+    NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0)
+}
+
+impl<Tz: TimeZone> Expression for DateTime<Tz>
+    where Tz::Offset: Display {
+    type SqlType = Timestamp;
+
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        let formatted_string = format!("{}", &self.format("%Y-%m-%d %H:%M:%S %:z"));
+        out.push_sql(&formatted_string);
+        Ok(())
+    }
+}
+
+
+impl Expression for NaiveDateTime {
+    type SqlType = Timestamp;
+
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        let formatted_string = format!("{}", self.format("%Y-%m-%d %H:%M:%S"));
+        out.push_sql(&formatted_string);
+        Ok(())
+    }
+}
+
+impl NonAggregate for DateTime<UTC> {}
+
+impl FromSql<Timestamp> for NaiveDateTime {
+    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error>> {
+        if let Some(mut buf) = bytes {
+            let offset: i64 = try!(buf.read_i64::<BigEndian>());
+            Ok(base() + Duration::microseconds(offset))
+        } else {
+            let err: Box<Error + Send + Sync> = "Nothing to read!".into();
+            Err(err)
+        }
+    }
+}
+
+impl FromSql<Timestamp> for DateTime<UTC> {
+    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error>> {
+        let naive = try!(NaiveDateTime::from_sql(bytes));
+        Ok(DateTime::from_utc(naive, UTC))
+    }
+}
+
+impl FromSql<Timestamp> for DateTime<Local> {
+    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error>> {
+        let utc = try!(DateTime::<UTC>::from_sql(bytes));
+        Ok(utc.with_timezone(&Local))
+    }
+}
+
+impl FromSql<Timestamp> for DateTime<FixedOffset> {
+    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error>> {
+        let utc = try!(DateTime::<UTC>::from_sql(bytes));
+        Ok(utc.with_timezone(&FixedOffset::east(0))) // i.e. UTC
+    }
+}
+
+impl ToSql<Timestamp> for NaiveDateTime {
+    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error>> {
+        let time = match (*self - base()).num_microseconds() {
+            Some(time) => time,
+            None => {
+                let err: Box<Error + Send + Sync> = "value is too large to transmit".into();
+                return Err(err);
+            }
+        };
+        try!(out.write_i64::<BigEndian>(time));
+        Ok(IsNull::No)
+    }
+}
+
+impl ToSql<Timestamp> for DateTime<UTC> {
+    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error>> {
+        let naive: NaiveDateTime = self.naive_utc();
+        ToSql::<Timestamp>::to_sql(&naive, out)
+    }
+}
+
+impl ToSql<Timestamp> for DateTime<FixedOffset> {
+    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error>> {
+        let naive: NaiveDateTime = self.naive_utc();
+        ToSql::<Timestamp>::to_sql(&naive, out)
+    }
+}
+
+impl ToSql<Timestamp> for DateTime<Local> {
+    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error>> {
+        let naive: NaiveDateTime = self.naive_utc();
+        ToSql::<Timestamp>::to_sql(&naive, out)
+    }
+}
+
+#[test]
+fn utc_datetime_to_sql() {
+    let mut bytes = vec![];
+    ToSql::<Timestamp>::to_sql(&UTC.ymd(2000, 1, 1).and_hms(0, 0, 0), &mut bytes).unwrap();
+    ToSql::<Timestamp>::to_sql(&UTC.ymd(2010, 12, 4).and_hms(14, 39, 6), &mut bytes).unwrap();
+    ToSql::<Timestamp>::to_sql(&UTC.ymd(2032, 2, 4).and_hms(12, 59, 59), &mut bytes).unwrap();
+    assert_eq!(bytes,
+               vec![
+               0,0,0,0,0,0,0,0,
+               0x00,0x01,0x39,0x95,0x62,0xba,0x56,0x80,
+               0x00,0x03,0x99,0x29,0x4d,0x41,0xd1,0xc0,
+               ]);
+}

--- a/diesel/src/types/impls/date_and_time/mod.rs
+++ b/diesel/src/types/impls/date_and_time/mod.rs
@@ -12,6 +12,8 @@ use types::{self, NativeSqlType, FromSql, ToSql, IsNull};
 mod quickcheck_impls;
 #[cfg(feature = "unstable")]
 mod std_time;
+#[cfg(feature = "chrono")]
+mod chrono;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Timestamps are represented in Postgres as a 32 bit signed integer representing the number of


### PR DESCRIPTION
As discussed in issue #92, I started writing `impl`s for diesel to handle chrono’s `DateTime` type. This is strongly inspired by the implementation of same feature in the postgres crate.

Only `DateTime` is handled at the moment. Tests are far from complete.

I wonder if it would not be possible to implement `FromSql` and `ToSql` for `DateTime<T: TimeZone>` and avoid having to provide implementations for `UTC`, `FixedOffset` and `Local`. The whole timezones business is a bit fuzzy in my head as soon as it strays too far from “UTC everywhere”.

I have a two questions:

- Shouldn’t
[this](https://github.com/sgrif/diesel/blob/master/diesel/src/types/impls/date_and_time/mod.rs#L17)
read “Timestamps are represented in Postgres as a *64 bit* signed integer”? If so, should this be in a separate PR?
- As converting from `DateTime` to `Date` (for example) is easy, should  there be impls like `impl ToSql<Date> for NaiveDateTime`, or should mappings between types be strict?