### PR TITLE
Implement FromSql and ToSql for `chrono::NaiveTime`

### DIFF
--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -1,7 +1,7 @@
 extern crate chrono;
 
 pub use quickcheck::quickcheck;
-use self::chrono::NaiveDateTime;
+use self::chrono::{NaiveDateTime, NaiveTime};
 
 pub use schema::connection;
 pub use diesel::*;
@@ -80,9 +80,14 @@ test_round_trip!(timestamp_roundtrips, Timestamp, PgTimestamp);
 test_round_trip!(interval_roundtrips, Interval, PgInterval);
 test_round_trip!(numeric_roundtrips, Numeric, PgNumeric);
 test_round_trip!(naive_datetime_roundtrips, Timestamp, (i64, u32), mk_naive_datetime);
+test_round_trip!(naive_time_roundtrips, Time, (u32, u32), mk_naive_time);
 
 fn mk_naive_datetime(data: (i64, u32)) -> NaiveDateTime {
     NaiveDateTime::from_timestamp(data.0, data.1 / 1000)
+}
+
+fn mk_naive_time(data: (u32, u32)) -> NaiveTime {
+    NaiveTime::from_num_seconds_from_midnight(data.0, data.1 / 1000)
 }
 
 #[cfg(feature = "unstable")]


### PR DESCRIPTION
The basic tests seem to work, as well as the types_roundtrip one, though it uses unconstrained `u32`s for second and microsecond values and I’m not sure it is the right way to do it.

Also, the formatting is sometimes off in the tests because I let rustfmt handle it. I can improve it if necessary.

EDIT: I changed a first ugly implementation to use `Duration`s instead.

~~EDIT2: The tests pass, but they are not functioning apparently (changing the times in the SQL strings does not make them fail).~~