### PR TITLE
Add support for `chrono::NaiveDate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
-* Added support for mapping `types::Timestamp` to/from `chrono::NaiveDateTime`.
+* Added support for mapping `types::Timestamp`, `types::Date`, and `types::Time`
+  to/from `chrono::NaiveDateTime`, `chrono::NaiveDate`, and `chrono::NaiveTime`.
   Add `features = ["chrono"]` to enable.
 
 * Added a top level `select` function for select statements with no from clause.

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -1,7 +1,8 @@
 extern crate chrono;
 
 pub use quickcheck::quickcheck;
-use self::chrono::{NaiveDateTime, NaiveTime};
+use self::chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime};
+use self::chrono::naive::date;
 
 pub use schema::connection;
 pub use diesel::*;
@@ -81,6 +82,7 @@ test_round_trip!(interval_roundtrips, Interval, PgInterval);
 test_round_trip!(numeric_roundtrips, Numeric, PgNumeric);
 test_round_trip!(naive_datetime_roundtrips, Timestamp, (i64, u32), mk_naive_datetime);
 test_round_trip!(naive_time_roundtrips, Time, (u32, u32), mk_naive_time);
+test_round_trip!(naive_date_roundtrips, Date, u32, mk_naive_date);
 
 fn mk_naive_datetime(data: (i64, u32)) -> NaiveDateTime {
     NaiveDateTime::from_timestamp(data.0, data.1 / 1000)
@@ -88,6 +90,13 @@ fn mk_naive_datetime(data: (i64, u32)) -> NaiveDateTime {
 
 fn mk_naive_time(data: (u32, u32)) -> NaiveTime {
     NaiveTime::from_num_seconds_from_midnight(data.0, data.1 / 1000)
+}
+
+fn mk_naive_date(days: u32) -> NaiveDate {
+    let earliest_pg_date = NaiveDate::from_ymd(-4713, 11, 24);
+    let latest_chrono_date = date::MAX;
+    let num_days_representable = (latest_chrono_date - earliest_pg_date).num_days();
+    earliest_pg_date + Duration::days(days as i64 % num_days_representable)
 }
 
 #[cfg(feature = "unstable")]


### PR DESCRIPTION
Much like the previous PRs, this one adds `chrono::NaiveDate` support.
Much of the code is from c0b0fb8.

I was very confused by the Julian-Gregorian conversions at one point
(hence the many unit tests, also the names of variables may not be the
best), but the situation appears to be quite simple if dates are treated
as a plain number of days before or after January 1st, 2000, including
distant dates.

Unless the “J*n*” (where *n* is a number of Julian days) format is used,
input and output expressions are dates in the *Gregorian* calendar.

The earliest date that can be stored by postgres is J0 (November 24,
4714 BCE) and the latest that can be represented by chrono is December
31, 262143.

(Should I write tests with `#[should_panic]` for that?)

I also took the liberty of updating the changelog.