### PR TITLE
Add `Expression#nullable` to allow comparing null and not null exprs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   instead of skipping the field entirely. The default value of the option is
   `false`, as we think the current behavior is a much more common use case.
 
+* Added `Expression#nullable()`, to allow comparisons of not null columns with
+  nullable ones when required.
+
 ### Changed
 
 * Rename both the `#[derive(Queriable)]` attribute and the `Queriable` trait to

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -35,6 +35,8 @@ pub mod functions;
 pub mod grouped;
 pub mod helper_types;
 #[doc(hidden)]
+pub mod nullable;
+#[doc(hidden)]
 pub mod ordering;
 #[doc(hidden)]
 pub mod predicates;

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -1,0 +1,38 @@
+use expression::{Expression, SelectableExpression, NonAggregate};
+use query_builder::{QueryBuilder, BuildQueryResult};
+use types::IntoNullable;
+
+pub struct Nullable<T>(T);
+
+impl<T> Nullable<T> {
+    pub fn new(expr: T) -> Self {
+        Nullable(expr)
+    }
+}
+
+impl<T> Expression for Nullable<T> where
+    T: Expression,
+    <T as Expression>::SqlType: IntoNullable,
+{
+    type SqlType = <<T as Expression>::SqlType as IntoNullable>::Nullable;
+
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        self.0.to_sql(out)
+    }
+
+    fn to_insert_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        self.0.to_insert_sql(out)
+    }
+}
+
+impl<T, QS> SelectableExpression<QS> for Nullable<T> where
+    T: SelectableExpression<QS>,
+    Nullable<T>: Expression,
+{
+}
+
+impl<T> NonAggregate for Nullable<T> where
+    T: NonAggregate,
+    Nullable<T>: Expression,
+{
+}

--- a/diesel/src/macros.rs
+++ b/diesel/src/macros.rs
@@ -287,7 +287,7 @@ macro_rules! joinable_inner {
                 try!($parent::table.from_clause(out));
                 out.push_sql(" ON ");
 
-                $child::$source.eq($parent::$target).to_sql(out)
+                $child::$source.nullable().eq($parent::$target.nullable()).to_sql(out)
             }
         }
     }

--- a/diesel_codegen/src/associations/has_many.rs
+++ b/diesel_codegen/src/associations/has_many.rs
@@ -83,7 +83,7 @@ fn join_to_impl(builder: &HasManyAssociationBuilder) -> P<ast::Item> {
                 try!($foreign_table.from_clause(out));
                 out.push_sql(" ON ");
                 ::diesel::expression::Expression::to_sql(
-                    &$foreign_key.eq($table.primary_key()),
+                    &$foreign_key.nullable().eq($table.primary_key().nullable()),
                     out,
                 )
             }

--- a/diesel_codegen/src/update.rs
+++ b/diesel_codegen/src/update.rs
@@ -1,13 +1,14 @@
-use syntax::ast::{self, MetaItem, TyPath};
+use syntax::ast::{self, MetaItem};
 use syntax::attr::AttrMetaMethods;
 use syntax::codemap::Span;
 use syntax::ext::base::{Annotatable, ExtCtxt};
 use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
-use syntax::parse::token::{InternedString, intern_and_get_ident, str_to_ident};
+use syntax::parse::token::{InternedString, str_to_ident};
 
 use attr::Attr;
 use model::Model;
+use util::ty_param_of_option;
 
 pub fn expand_changeset_for(
     cx: &mut ExtCtxt,
@@ -193,18 +194,6 @@ fn changeset_expr(
         quote_expr!(cx, self.$field_name.as_ref().map(|f| $column.eq(f)))
     } else {
         quote_expr!(cx, $column.eq(&self.$field_name))
-    }
-}
-
-fn ty_param_of_option(ty: &ast::Ty) -> Option<&P<ast::Ty>> {
-    match ty.node {
-        TyPath(_, ref path) => {
-            path.segments.first().iter()
-                .filter(|s| s.identifier.name.as_str() == intern_and_get_ident("Option"))
-                .flat_map(|s| s.parameters.types().first().map(|p| *p))
-                .next()
-        }
-        _ => None,
     }
 }
 

--- a/diesel_codegen/src/util.rs
+++ b/diesel_codegen/src/util.rs
@@ -3,7 +3,7 @@ use syntax::attr::AttrMetaMethods;
 use syntax::codemap::Span;
 use syntax::ext::base::ExtCtxt;
 use syntax::ext::build::AstBuilder;
-use syntax::parse::token::str_to_ident;
+use syntax::parse::token::{str_to_ident, intern_and_get_ident};
 use syntax::ptr::P;
 
 fn str_value_of_attr(
@@ -64,4 +64,16 @@ pub fn struct_ty(
         .map(|param| cx.ty_ident(span, param.ident))
         .collect();
     cx.ty_path(cx.path_all(span, false, vec![name], lifetimes, ty_params, Vec::new()))
+}
+
+pub fn ty_param_of_option(ty: &ast::Ty) -> Option<&P<ast::Ty>> {
+    match ty.node {
+        ast::TyPath(_, ref path) => {
+            path.segments.first().iter()
+                .filter(|s| s.identifier.name.as_str() == intern_and_get_ident("Option"))
+                .flat_map(|s| s.parameters.types().first().map(|p| *p))
+                .next()
+        }
+        _ => None,
+    }
 }

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -86,3 +86,33 @@ fn association_where_parent_and_child_have_underscores() {
 
     assert_eq!(special_post.id, comment.special_post_id);
 }
+
+// This module has no test functions, as it's only to test compilation.
+mod associations_can_have_nullable_foreign_keys {
+    #![allow(dead_code)]
+    use diesel::prelude::*;
+
+    table! {
+        foos{
+            id -> Serial,
+        }
+    }
+
+    table! {
+        bars {
+            id -> Serial,
+            foo_id -> Nullable<Integer>,
+        }
+    }
+    // This test has no assertions, as it is for compilation purposes only.
+    #[has_many(bars)]
+    pub struct Foo {
+        id: i32,
+    }
+
+    #[belongs_to(foo)]
+    pub struct Bar {
+        id: i32,
+        foo_id: Option<i32>,
+    }
+}


### PR DESCRIPTION
We currently don't allow a comparison like `Eq<Integer,
Nullable<Integer>>`. This is somewhat by design, but the goal was to
force you to explicitly declare that you want to do this, not to make it
impossible to do entirely. The `nullable` method will take a potentially
nullable expression, and ensure it is of a `nullable` type. Calling it
on an already `nullable` expression will not change the `SqlType`
(though it will end up wrapping it in our `Nullable` expression struct).
The resulting expression will have the same SQL as the original.

Our private API associations have also been updated to use this new
method, to allow for cases where there are optional foreign keys.

Fixes #116