### PR TITLE
Remove `Expression#to_insert_sql`

### DIFF
--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -33,20 +33,6 @@ impl<T, U> Expression for Bound<T, U> where
             }
         }
     }
-
-    fn to_insert_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
-        let mut bytes = Vec::new();
-        match try!(self.item.to_sql(&mut bytes)) {
-            IsNull::Yes => {
-                out.push_sql("DEFAULT");
-                Ok(())
-            }
-            IsNull::No => {
-                out.push_bound_value(&self.tpe, Some(bytes));
-                Ok(())
-            }
-        }
-    }
 }
 
 impl<T, U, QS> SelectableExpression<QS> for Bound<T, U> where

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -12,13 +12,6 @@ impl<T: Expression> Expression for Grouped<T> {
         out.push_sql(")");
         Ok(())
     }
-
-    fn to_insert_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
-        out.push_sql("(");
-        try!(self.0.to_insert_sql(out));
-        out.push_sql(")");
-        Ok(())
-    }
 }
 
 impl<T, QS> SelectableExpression<QS> for Grouped<T> where

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -71,11 +71,6 @@ pub trait Expression {
     type SqlType: NativeSqlType;
 
     fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult;
-
-    #[doc(hidden)]
-    fn to_insert_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
-        self.to_sql(out)
-    }
 }
 
 impl<T: Expression + ?Sized> Expression for Box<T> {
@@ -84,10 +79,6 @@ impl<T: Expression + ?Sized> Expression for Box<T> {
     fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
         Expression::to_sql(&**self, out)
     }
-
-    fn to_insert_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
-        Expression::to_insert_sql(&**self, out)
-    }
 }
 
 impl<'a, T: Expression + ?Sized> Expression for &'a T {
@@ -95,10 +86,6 @@ impl<'a, T: Expression + ?Sized> Expression for &'a T {
 
     fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
         Expression::to_sql(&**self, out)
-    }
-
-    fn to_insert_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
-        Expression::to_insert_sql(&**self, out)
     }
 }
 

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -19,10 +19,6 @@ impl<T> Expression for Nullable<T> where
     fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
         self.0.to_sql(out)
     }
-
-    fn to_insert_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
-        self.0.to_insert_sql(out)
-    }
 }
 
 impl<T, QS> SelectableExpression<QS> for Nullable<T> where

--- a/diesel/src/persistable.rs
+++ b/diesel/src/persistable.rs
@@ -76,15 +76,11 @@ impl<'a, T, U> Expression for InsertValues<'a, T, U> where
     type SqlType = <<&'a U as Insertable<T>>::Columns as InsertableColumns<T>>::SqlType;
 
     fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
-        self.to_insert_sql(out)
-    }
-
-    fn to_insert_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
         for (i, record) in self.values.into_iter().enumerate() {
             if i != 0 {
                 out.push_sql(", ");
             }
-            try!(record.values().to_insert_sql(out));
+            try!(record.values().to_sql(out));
         }
         Ok(())
     }

--- a/diesel/src/query_builder/debug.rs
+++ b/diesel/src/query_builder/debug.rs
@@ -1,11 +1,11 @@
-use super::{QueryBuilder, BuildQueryResult};
+use super::{QueryBuilder, BuildQueryResult, Context};
 use types::NativeSqlType;
 
 #[doc(hidden)]
 pub struct DebugQueryBuilder {
     pub sql: String,
     pub bind_types: Vec<u32>,
-    bind_idx: u32,
+    context_stack: Vec<Context>,
 }
 
 impl DebugQueryBuilder {
@@ -13,7 +13,7 @@ impl DebugQueryBuilder {
         DebugQueryBuilder {
             sql: String::new(),
             bind_types: Vec::new(),
-            bind_idx: 0,
+            context_stack: Vec::new(),
         }
     }
 }
@@ -27,9 +27,18 @@ impl QueryBuilder for DebugQueryBuilder {
         Ok(self.push_sql(&identifier))
     }
 
-    fn push_bound_value(&mut self, _tpe: &NativeSqlType, _bind: Option<Vec<u8>>) {
-        self.bind_idx += 1;
-        let sql = format!("${}", self.bind_idx);
-        self.push_sql(&sql);
+    fn push_bound_value(&mut self, _tpe: &NativeSqlType, bind: Option<Vec<u8>>) {
+        match (self.context_stack.first(), bind) {
+            (Some(&Context::Insert), None) => self.push_sql("DEFAULT"),
+            _ => self.push_sql("?"),
+        }
+    }
+
+    fn push_context(&mut self, context: Context) {
+        self.context_stack.push(context);
+    }
+
+    fn pop_context(&mut self) {
+        self.context_stack.pop();
     }
 }

--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -13,9 +13,12 @@ impl<T> QueryFragment for DeleteStatement<T> where
     T: UpdateTarget,
 {
     fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        out.push_context(Context::Delete);
         out.push_sql("DELETE FROM ");
         try!(self.0.from_clause(out));
-        self.0.where_clause(out)
+        try!(self.0.where_clause(out));
+        out.pop_context();
+        Ok(())
     }
 }
 

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -39,6 +39,19 @@ pub trait QueryBuilder {
     fn push_sql(&mut self, sql: &str);
     fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult;
     fn push_bound_value(&mut self, tpe: &NativeSqlType, binds: Option<Vec<u8>>);
+    fn push_context(&mut self, context: Context);
+    fn pop_context(&mut self);
+}
+
+/// Represents the current overall type of query being constructed. Used for
+/// example, to place the keyword `DEFAULT` instead of a bind param when a null
+/// bind param is pushed on insert.
+#[derive(Debug, Clone, Copy)]
+pub enum Context {
+    Select,
+    Insert,
+    Update,
+    Delete,
 }
 
 /// A complete SQL query with a return type. This can be a select statement, or

--- a/diesel/src/query_builder/pg.rs
+++ b/diesel/src/query_builder/pg.rs
@@ -1,5 +1,5 @@
 use connection::Connection;
-use super::{QueryBuilder, Binds, BuildQueryResult};
+use super::{QueryBuilder, Binds, BuildQueryResult, Context};
 use types::NativeSqlType;
 
 pub struct PgQueryBuilder<'a> {
@@ -8,6 +8,7 @@ pub struct PgQueryBuilder<'a> {
     pub binds: Binds,
     pub bind_types: Vec<u32>,
     bind_idx: u32,
+    context_stack: Vec<Context>,
 }
 
 impl<'a> PgQueryBuilder<'a> {
@@ -18,6 +19,7 @@ impl<'a> PgQueryBuilder<'a> {
             binds: Vec::new(),
             bind_types: Vec::new(),
             bind_idx: 0,
+            context_stack: Vec::new(),
         }
     }
 }
@@ -33,10 +35,23 @@ impl<'a> QueryBuilder for PgQueryBuilder<'a> {
     }
 
     fn push_bound_value(&mut self, tpe: &NativeSqlType, bind: Option<Vec<u8>>) {
-        self.bind_idx += 1;
-        let sql = format!("${}", self.bind_idx);
-        self.push_sql(&sql);
-        self.binds.push(bind);
-        self.bind_types.push(tpe.oid());
+        match (self.context_stack.first(), bind) {
+            (Some(&Context::Insert), None) => self.push_sql("DEFAULT"),
+            (_, bind) => {
+                self.bind_idx += 1;
+                let sql = format!("${}", self.bind_idx);
+                self.push_sql(&sql);
+                self.binds.push(bind);
+                self.bind_types.push(tpe.oid());
+            }
+        }
+    }
+
+    fn push_context(&mut self, context: Context) {
+        self.context_stack.push(context);
+    }
+
+    fn pop_context(&mut self) {
+        self.context_stack.pop();
     }
 }

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -3,7 +3,7 @@ mod dsl_impls;
 use expression::*;
 use query_source::{QuerySource, Table, LeftOuterJoinSource, InnerJoinSource, JoinTo};
 use std::marker::PhantomData;
-use super::{Query, QueryBuilder, QueryFragment, BuildQueryResult};
+use super::{Query, QueryBuilder, QueryFragment, BuildQueryResult, Context};
 use super::limit_clause::NoLimitClause;
 use super::offset_clause::NoOffsetClause;
 use super::order_clause::NoOrderClause;
@@ -87,6 +87,7 @@ impl<ST, S, F, W, O, L, Of> Expression for SelectStatement<ST, S, F, W, O, L, Of
     type SqlType = types::Array<ST>;
 
     fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        out.push_context(Context::Select);
         out.push_sql("SELECT ");
         try!(self.select.to_sql(out));
         out.push_sql(" FROM ");
@@ -94,7 +95,9 @@ impl<ST, S, F, W, O, L, Of> Expression for SelectStatement<ST, S, F, W, O, L, Of
         try!(self.where_clause.to_sql(out));
         try!(self.order.to_sql(out));
         try!(self.limit.to_sql(out));
-        self.offset.to_sql(out)
+        try!(self.offset.to_sql(out));
+        out.pop_context();
+        Ok(())
     }
 }
 
@@ -109,12 +112,15 @@ impl<ST, S, W, O, L, Of> Expression for SelectStatement<ST, S, (), W, O, L, Of> 
     type SqlType = types::Array<ST>;
 
     fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        out.push_context(Context::Select);
         out.push_sql("SELECT ");
         try!(self.select.to_sql(out));
         try!(self.where_clause.to_sql(out));
         try!(self.order.to_sql(out));
         try!(self.limit.to_sql(out));
-        self.offset.to_sql(out)
+        try!(self.offset.to_sql(out));
+        out.pop_context();
+        Ok(())
     }
 }
 

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -81,17 +81,6 @@ macro_rules! tuple_impls {
                     )+
                     Ok(())
                 }
-
-                fn to_insert_sql(&self, out: &mut QueryBuilder)
-                -> BuildQueryResult {
-                    $(
-                        if e!($idx) != 0 {
-                            out.push_sql(", ");
-                        }
-                        try!(e!(self.$idx.to_insert_sql(out)));
-                    )+
-                    Ok(())
-                }
             }
 
             impl<$($T: Expression + NonAggregate),+> NonAggregate for ($($T,)+) {

--- a/diesel_tests/tests/debug/mod.rs
+++ b/diesel_tests/tests/debug/mod.rs
@@ -12,5 +12,5 @@ fn test_debug_count_output() {
 fn test_debug_output() {
     use schema::users::dsl::*;
     let command = update(users.filter(id.eq(1))).set(name.eq("new_name"));
-    assert_eq!(debug_sql!(command), "UPDATE users SET name = $1 WHERE users.id = $2")
+    assert_eq!(debug_sql!(command), "UPDATE users SET name = ? WHERE users.id = ?")
 }


### PR DESCRIPTION
This is part of a larger refactoring which will be coming in many steps.
This piece is a prerequisite for basically everything else.

`to_insert_sql` has been a general wart in our implementation that was a
side effect of how we used to structure things. Ultimately the only way
that it's really used is to replace null bind params with `DEFAULT` on
inserts.

This cleans up our code a good bit, and starts to allow us to separate
`Expression` and `QueryFragment` into more decoupled entities, which
will be important going forward.