### PR TITLE
Remove `QueryBuilder` related methods from `UpdateTarget`

### DIFF
--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -11,12 +11,16 @@ impl<T> DeleteStatement<T> {
 
 impl<T> QueryFragment for DeleteStatement<T> where
     T: UpdateTarget,
+    T::WhereClause: QueryFragment,
 {
     fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
         out.push_context(Context::Delete);
         out.push_sql("DELETE FROM ");
         try!(self.0.from_clause(out));
-        try!(self.0.where_clause(out));
+        if let Some(clause) =  self.0.where_clause() {
+            out.push_sql(" WHERE ");
+            try!(clause.to_sql(out));
+        }
         out.pop_context();
         Ok(())
     }

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -87,6 +87,12 @@ impl<'a, T: QueryFragment + ?Sized> QueryFragment for &'a T {
     }
 }
 
+impl QueryFragment for () {
+    fn to_sql(&self, _out: &mut QueryBuilder) -> BuildQueryResult {
+        Ok(())
+    }
+}
+
 /// Types that can be converted into a complete, typed SQL query. This is used
 /// internally to automatically add the right select clause when none is
 /// specified, or to automatically add `RETURNING *` in certain contexts

--- a/diesel/src/query_builder/update_statement/target.rs
+++ b/diesel/src/query_builder/update_statement/target.rs
@@ -1,4 +1,3 @@
-use query_builder::{QueryBuilder, BuildQueryResult};
 use query_source::{QuerySource, Table};
 
 /// You should not need to implement this trait.
@@ -13,6 +12,7 @@ use query_source::{QuerySource, Table};
 /// the context of an `update` or `delete` operation.
 pub trait UpdateTarget: QuerySource {
     type Table: Table;
+    type WhereClause;
 
-    fn where_clause(&self, out: &mut QueryBuilder) -> BuildQueryResult;
+    fn where_clause(&self) -> Option<&Self::WhereClause>;
 }

--- a/diesel/src/query_source/filter.rs
+++ b/diesel/src/query_source/filter.rs
@@ -62,9 +62,9 @@ impl<Source, Predicate> UpdateTarget for FilteredQuerySource<Source, Predicate> 
     Predicate: SelectableExpression<Source, SqlType=Bool> + QueryFragment,
 {
     type Table = Source::Table;
+    type WhereClause = Predicate;
 
-    fn where_clause(&self, out: &mut QueryBuilder) -> BuildQueryResult {
-        out.push_sql(" WHERE ");
-        self.predicate.to_sql(out)
+    fn where_clause(&self) -> Option<&Self::WhereClause> {
+        Some(&self.predicate)
     }
 }

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -63,8 +63,9 @@ pub trait Table: QuerySource + AsQuery + Sized {
 
 impl<T: Table> UpdateTarget for T {
     type Table = Self;
+    type WhereClause = ();
 
-    fn where_clause(&self, _out: &mut QueryBuilder) -> BuildQueryResult {
-        Ok(())
+    fn where_clause(&self) -> Option<&Self::WhereClause> {
+        None
     }
 }


### PR DESCRIPTION
This is part of an ongoing refactoring to remove all methods which take
a `&mut QueryBuilder` other than those on `QueryFragment`. The goal is
to reduce the number of places that need to know about conversion to
SQL, thus reducing the number of things that need to become generic over
the backend in the future.