### PR TITLE
Remove `QueryBuilder` related methods from `JoinTo`

### DIFF
--- a/diesel/src/expression/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression/expression_methods/global_expression_methods.rs
@@ -286,7 +286,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// #      author_name: Option<VarChar>,
     /// #  }
     /// #
-    /// #  joinable!(posts -> users (user_id = id));
+    /// #  joinable!(posts -> users (user_id));
     /// #  select_column_workaround!(posts -> users (id, user_id, author_name));
     /// #  select_column_workaround!(users -> posts (id, name));
     ///

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -6,6 +6,8 @@ pub mod debug;
 mod delete_statement;
 #[doc(hidden)]
 pub mod functions;
+#[doc(hidden)]
+pub mod nodes;
 #[macro_use]
 mod clause_macro;
 mod limit_clause;

--- a/diesel/src/query_builder/nodes/mod.rs
+++ b/diesel/src/query_builder/nodes/mod.rs
@@ -1,0 +1,63 @@
+use query_builder::{QueryBuilder, BuildQueryResult, QueryFragment};
+
+pub struct Identifier<'a>(pub &'a str);
+
+impl<'a> QueryFragment for Identifier<'a> {
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        out.push_identifier(self.0)
+    }
+}
+
+pub struct Join<T, U, V, W> {
+    lhs: T,
+    rhs: U,
+    predicate: V,
+    join_type: W,
+}
+
+impl<T, U, V, W> Join<T, U, V, W> {
+    pub fn new(lhs: T, rhs: U, predicate: V, join_type: W) -> Self {
+        Join {
+            lhs: lhs,
+            rhs: rhs,
+            predicate: predicate,
+            join_type: join_type,
+        }
+    }
+}
+
+pub trait CombinedJoin<Other> {
+    type Output;
+
+    fn combine_with(self, other: Other) -> Self::Output;
+}
+
+impl<T, U, UU, V, VV, W, WW> CombinedJoin<Join<U, UU, VV, WW>> for Join<T, U, V, W> {
+    type Output = Join<
+        Self,
+        UU,
+        VV,
+        WW,
+    >;
+
+    fn combine_with(self, other: Join<U, UU, VV, WW>) -> Self::Output {
+        Join::new(self, other.rhs, other.predicate, other.join_type)
+    }
+}
+
+impl<T, U, V, W> QueryFragment for Join<T, U, V, W> where
+    T: QueryFragment,
+    U: QueryFragment,
+    V: QueryFragment,
+    W: QueryFragment,
+{
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        try!(self.lhs.to_sql(out));
+        try!(self.join_type.to_sql(out));
+        out.push_sql(" JOIN ");
+        try!(self.rhs.to_sql(out));
+        out.push_sql(" ON ");
+        try!(self.predicate.to_sql(out));
+        Ok(())
+    }
+}

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -1,7 +1,7 @@
 mod dsl_impls;
 
 use expression::*;
-use query_source::{QuerySource, Table, LeftOuterJoinSource, InnerJoinSource, JoinTo};
+use query_source::*;
 use std::marker::PhantomData;
 use super::{Query, QueryBuilder, QueryFragment, BuildQueryResult, Context};
 use super::limit_clause::NoLimitClause;
@@ -46,7 +46,7 @@ impl<ST, S, F, W, O, L, Of> SelectStatement<ST, S, F, W, O, L, Of> {
     pub fn inner_join<T>(self, other: T)
         -> SelectStatement<ST, S, InnerJoinSource<F, T>, W, O, L, Of> where
             T: Table,
-            F: Table + JoinTo<T>,
+            F: Table + JoinTo<T, joins::Inner>,
     {
         SelectStatement::new(self.select, self.from.inner_join(other),
             self.where_clause, self.order, self.limit, self.offset)
@@ -55,7 +55,7 @@ impl<ST, S, F, W, O, L, Of> SelectStatement<ST, S, F, W, O, L, Of> {
     pub fn left_outer_join<T>(self, other: T)
         -> SelectStatement<ST, S, LeftOuterJoinSource<F, T>, W, O, L, Of> where
             T: Table,
-            F: Table + JoinTo<T>,
+            F: Table + JoinTo<T, joins::LeftOuter>,
     {
         SelectStatement::new(self.select, self.from.left_outer_join(other),
             self.where_clause, self.order, self.limit, self.offset)

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -3,7 +3,8 @@
 //! the methods on [`Table`](trait.Table.html)
 #[doc(hidden)]
 pub mod filter;
-mod joins;
+#[doc(hidden)]
+pub mod joins;
 
 use expression::{Expression, SelectableExpression, NonAggregate};
 use query_builder::*;
@@ -48,14 +49,14 @@ pub trait Table: QuerySource + AsQuery + Sized {
 
     fn inner_join<T>(self, other: T) -> InnerJoinSource<Self, T> where
         T: Table,
-        Self: JoinTo<T>,
+        Self: JoinTo<T, joins::Inner>,
     {
         InnerJoinSource::new(self, other)
     }
 
     fn left_outer_join<T>(self, other: T) -> LeftOuterJoinSource<Self, T> where
         T: Table,
-        Self: JoinTo<T>,
+        Self: JoinTo<T, joins::LeftOuter>,
     {
         LeftOuterJoinSource::new(self, other)
     }

--- a/diesel_codegen/src/associations/belongs_to.rs
+++ b/diesel_codegen/src/associations/belongs_to.rs
@@ -140,16 +140,7 @@ fn join_to_impl(builder: &BelongsToAssociationBuilder) -> P<ast::Item> {
     let foreign_key = builder.foreign_key();
 
     quote_item!(builder.cx,
-        impl ::diesel::JoinTo<$parent_table> for $child_table {
-            fn join_sql(&self, out: &mut ::diesel::query_builder::QueryBuilder)
-                -> ::diesel::query_builder::BuildQueryResult
-            {
-                try!($parent_table.from_clause(out));
-                out.push_sql(" ON ");
-                ::diesel::query_builder::QueryFragment::to_sql(
-                    &$foreign_key.nullable().eq($parent_table.primary_key().nullable()), out)
-            }
-        }
+        joinable_inner!($child_table => $parent_table : ($foreign_key = $parent_table));
     ).unwrap()
 }
 

--- a/diesel_codegen/src/associations/has_many.rs
+++ b/diesel_codegen/src/associations/has_many.rs
@@ -76,18 +76,7 @@ fn join_to_impl(builder: &HasManyAssociationBuilder) -> P<ast::Item> {
     let foreign_key = builder.foreign_key();
 
     quote_item!(builder.cx,
-        impl ::diesel::JoinTo<$foreign_table> for $table {
-            fn join_sql(&self, out: &mut ::diesel::query_builder::QueryBuilder)
-                -> ::diesel::query_builder::BuildQueryResult
-            {
-                try!($foreign_table.from_clause(out));
-                out.push_sql(" ON ");
-                ::diesel::query_builder::QueryFragment::to_sql(
-                    &$foreign_key.nullable().eq($table.primary_key().nullable()),
-                    out,
-                )
-            }
-        }
+        joinable_inner!($table => $foreign_table : ($foreign_key = $table));
     ).unwrap()
 }
 

--- a/diesel_codegen/src/schema_inference/data_structures.rs
+++ b/diesel_codegen/src/schema_inference/data_structures.rs
@@ -19,7 +19,7 @@ table! {
     }
 }
 
-joinable!(pg_attribute -> pg_type (atttypid = oid));
+joinable!(pg_attribute -> pg_type (atttypid));
 select_column_workaround!(pg_attribute -> pg_type (attrelid, attname, atttypid, attnotnull, attnum, attisdropped));
 select_column_workaround!(pg_type -> pg_attribute (oid, typname));
 


### PR DESCRIPTION
This is part of an ongoing refactoring to consolidate all `to_sql` type
methods on `QueryFragment`

This code gets a little bit messy in places, particularly in keeping
`join_through!` around. This will eventually go away, but there is some
interesting bits in the `CombineJoin` trait which makes me think we
might be able to derive `join_through` in interesting ways.

The code will likly get a little bit cleaner once I do this same
refactoring to `QuerySource`.

I beleive that with this change we can actually remove `InnerJoinSource`
and `LeftOuterJoinSource` but I haven't explored it just yet.