### PR TITLE
Make `QueryFragment` generic over the backend, return to monomorphisation

### DIFF
--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -1,0 +1,19 @@
+use query_builder::QueryBuilder;
+use query_builder::pg::PgQueryBuilder;
+use query_builder::debug::DebugQueryBuilder;
+
+pub trait Backend {
+    type QueryBuilder: QueryBuilder;
+}
+
+pub struct Debug;
+
+impl Backend for Debug {
+    type QueryBuilder = DebugQueryBuilder;
+}
+
+pub struct Pg;
+
+impl Backend for Pg {
+    type QueryBuilder = PgQueryBuilder;
+}

--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -11,6 +11,7 @@ use std::ffi::{CString, CStr};
 use std::rc::Rc;
 use std::ptr;
 
+use backend::Pg;
 use db_result::DbResult;
 use expression::{AsExpression, Expression, NonAggregate};
 use expression::expression_methods::*;
@@ -115,7 +116,7 @@ impl Connection {
     #[doc(hidden)]
     pub fn query_one<T, U>(&self, source: T) -> QueryResult<U> where
         T: AsQuery,
-        T::Query: QueryFragment,
+        T::Query: QueryFragment<Pg>,
         U: Queryable<T::SqlType>,
     {
         self.query_all(source)
@@ -125,7 +126,7 @@ impl Connection {
     #[doc(hidden)]
     pub fn query_all<T, U>(&self, source: T) -> QueryResult<Cursor<T::SqlType, U>> where
         T: AsQuery,
-        T::Query: QueryFragment,
+        T::Query: QueryFragment<Pg>,
         U: Queryable<T::SqlType>,
     {
         let (sql, params, types) = self.prepare_query(&source.as_query());
@@ -191,7 +192,7 @@ impl Connection {
     pub fn find<T, U, PK>(&self, source: T, id: PK) -> QueryResult<U> where
         T: Table + FilterDsl<FindPredicate<T, PK>>,
         FindBy<T, T::PrimaryKey, PK>: LimitDsl,
-        Limit<FindBy<T, T::PrimaryKey, PK>>: QueryFragment,
+        Limit<FindBy<T, T::PrimaryKey, PK>>: QueryFragment<Pg>,
         U: Queryable<<Limit<FindBy<T, T::PrimaryKey, PK>> as Query>::SqlType>,
         PK: AsExpression<PkType<T>>,
         AsExpr<PK, T::PrimaryKey>: NonAggregate,
@@ -202,14 +203,14 @@ impl Connection {
 
     #[doc(hidden)]
     pub fn execute_returning_count<T>(&self, source: &T) -> QueryResult<usize> where
-        T: QueryFragment,
+        T: QueryFragment<Pg>,
     {
         let (sql, params, param_types) = self.prepare_query(source);
         self.exec_sql_params(&sql, &params, &Some(param_types))
             .map(|r| r.rows_affected())
     }
 
-    fn prepare_query<T: QueryFragment>(&self, source: &T)
+    fn prepare_query<T: QueryFragment<Pg>>(&self, source: &T)
         -> (String, Vec<Option<Vec<u8>>>, Vec<u32>)
     {
         let mut query_builder = PgQueryBuilder::new(&self.raw_connection);

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -1,6 +1,7 @@
 extern crate dotenv;
 
 use diesel::prelude::*;
+use diesel::backend;
 use self::dotenv::dotenv;
 
 fn connection_no_data() -> diesel::Connection {

--- a/diesel/src/expression/aliased.rs
+++ b/diesel/src/expression/aliased.rs
@@ -1,3 +1,4 @@
+use backend::Backend;
 use expression::{Expression, NonAggregate, SelectableExpression};
 use query_builder::*;
 use query_builder::nodes::{Identifier, InfixNode};
@@ -26,10 +27,11 @@ impl<'a, T> Expression for Aliased<'a, T> where
     type SqlType = T::SqlType;
 }
 
-impl<'a, T> QueryFragment for Aliased<'a, T> where
-    T: QueryFragment,
+impl<'a, T, DB> QueryFragment<DB> for Aliased<'a, T> where
+    DB: Backend,
+    T: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_identifier(&self.alias)
     }
 }

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use backend::Backend;
 use query_builder::*;
 use super::{AsExpression, Expression, SelectableExpression, NonAggregate};
 use types::{Array, NativeSqlType};
@@ -63,10 +64,11 @@ impl<Expr, ST> Expression for Any<Expr, ST> where
     type SqlType = ST;
 }
 
-impl<Expr, ST> QueryFragment for Any<Expr, ST> where
-    Expr: QueryFragment,
+impl<Expr, ST, DB> QueryFragment<DB> for Any<Expr, ST> where
+    DB: Backend,
+    Expr: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_sql("ANY(");
         try!(self.expr.to_sql(out));
         out.push_sql(")");

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -1,3 +1,4 @@
+use backend::Backend;
 use query_builder::*;
 use super::{Expression, SelectableExpression, NonAggregate};
 use types::{NativeSqlType, ToSql, IsNull};
@@ -20,11 +21,12 @@ impl<T, U> Expression for Bound<T, U> where
     type SqlType = T;
 }
 
-impl<T, U> QueryFragment for Bound<T, U> where
+impl<T, U, DB> QueryFragment<DB> for Bound<T, U> where
+    DB: Backend,
     T: NativeSqlType,
     U: ToSql<T>,
 {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         let mut bytes = Vec::new();
         match try!(self.item.to_sql(&mut bytes)) {
             IsNull::Yes => {

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -1,3 +1,4 @@
+use backend::Backend;
 use query_builder::*;
 use super::{Expression, SelectableExpression};
 use types::BigInt;
@@ -54,8 +55,8 @@ impl<T: Expression> Expression for Count<T> {
     type SqlType = BigInt;
 }
 
-impl<T: QueryFragment> QueryFragment for Count<T> {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Count<T> {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_sql("COUNT(");
         try!(self.target.to_sql(out));
         out.push_sql(")");
@@ -74,8 +75,8 @@ impl Expression for CountStar {
     type SqlType = BigInt;
 }
 
-impl QueryFragment for CountStar {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+impl<DB: Backend> QueryFragment<DB> for CountStar {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_sql("COUNT(*)");
         Ok(())
     }

--- a/diesel/src/expression/date_and_time.rs
+++ b/diesel/src/expression/date_and_time.rs
@@ -1,3 +1,4 @@
+use backend::Backend;
 use expression::{Expression, SelectableExpression};
 use query_builder::*;
 use types::{Timestamp, VarChar};
@@ -24,11 +25,12 @@ impl<Ts, Tz> Expression for AtTimeZone<Ts, Tz> where
     type SqlType = Timestamp;
 }
 
-impl<Ts, Tz> QueryFragment for AtTimeZone<Ts, Tz> where
-    Ts: QueryFragment,
-    Tz: QueryFragment,
+impl<Ts, Tz, DB> QueryFragment<DB> for AtTimeZone<Ts, Tz> where
+    DB: Backend,
+    Ts: QueryFragment<DB>,
+    Tz: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         try!(self.timestamp.to_sql(out));
         out.push_sql(" AT TIME ZONE ");
         self.timezone.to_sql(out)

--- a/diesel/src/expression/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression/expression_methods/global_expression_methods.rs
@@ -237,7 +237,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # fn main() {
     /// #     use self::users::dsl::*;
     /// #     let order = "name";
-    /// let ordering: Box<BoxableExpression<users, (), SqlType=()>> =
+    /// let ordering: Box<BoxableExpression<users, (), backend::Pg, SqlType=()>> =
     ///     if order == "name" {
     ///         Box::new(name.desc())
     ///     } else {

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -1,3 +1,4 @@
+use backend::Backend;
 use expression::{Expression, SelectableExpression};
 use query_builder::*;
 use types::{SqlOrd, NativeSqlType};
@@ -23,8 +24,8 @@ macro_rules! ord_function {
             type SqlType = T::SqlType;
         }
 
-        impl<T: QueryFragment> QueryFragment for $type_name<T> {
-            fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for $type_name<T> {
+            fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
                 out.push_sql(concat!($operator, "("));
                 try!(self.target.to_sql(out));
                 out.push_sql(")");

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -34,11 +34,13 @@ macro_rules! sql_function_body {
         }
 
         #[allow(non_camel_case_types)]
-        impl<$($arg_name),*> $crate::query_builder::QueryFragment for $struct_name<$($arg_name),*> where
-            for <'a> ($(&'a $arg_name),*): $crate::query_builder::QueryFragment,
+        impl<$($arg_name),*, DB> $crate::query_builder::QueryFragment<DB> for $struct_name<$($arg_name),*> where
+            DB: $crate::backend::Backend,
+            for <'a> ($(&'a $arg_name),*): $crate::query_builder::QueryFragment<DB>,
         {
-            fn to_sql(&self, out: &mut $crate::query_builder::QueryBuilder)
+            fn to_sql(&self, out: &mut DB::QueryBuilder)
                 -> $crate::query_builder::BuildQueryResult {
+                    use $crate::query_builder::QueryBuilder;
                     out.push_sql(concat!(stringify!($fn_name), "("));
                     try!($crate::query_builder::QueryFragment::to_sql(
                         &($(&self.$arg_name),*), out));
@@ -114,9 +116,12 @@ macro_rules! no_arg_sql_function_body {
             type SqlType = $return_type;
         }
 
-        impl $crate::query_builder::QueryFragment for $type_name {
-            fn to_sql(&self, out: &mut $crate::query_builder::QueryBuilder)
+        impl<DB> $crate::query_builder::QueryFragment<DB> for $type_name where
+            DB: $crate::backend::Backend,
+        {
+            fn to_sql(&self, out: &mut DB::QueryBuilder)
                 -> $crate::query_builder::BuildQueryResult {
+                    use $crate::query_builder::QueryBuilder;
                     out.push_sql(concat!(stringify!($type_name), "()"));
                     Ok(())
                 }

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -1,3 +1,4 @@
+use backend::Backend;
 use expression::{Expression, SelectableExpression, NonAggregate};
 use query_builder::*;
 
@@ -7,8 +8,8 @@ impl<T: Expression> Expression for Grouped<T> {
     type SqlType = T::SqlType;
 }
 
-impl<T: QueryFragment> QueryFragment for Grouped<T> {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Grouped<T> {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_sql("(");
         try!(self.0.to_sql(out));
         out.push_sql(")");

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -56,6 +56,7 @@ pub mod dsl {
 pub use self::dsl::*;
 pub use self::sql_literal::SqlLiteral;
 
+use backend::Backend;
 use types::NativeSqlType;
 
 /// Represents a typed fragment of SQL. Apps should not need to implement this
@@ -144,11 +145,21 @@ use query_builder::QueryFragment;
 /// Helper trait used when boxing expressions. This exists to work around the
 /// fact that Rust will not let us use non-core types as bounds on a trait
 /// object (you could not return `Box<Expression+NonAggregate>`)
-pub trait BoxableExpression<QS, ST: NativeSqlType>: Expression + SelectableExpression<QS, ST> + NonAggregate + QueryFragment {
-}
-
-impl<QS, T, ST> BoxableExpression<QS, ST> for T where
+pub trait BoxableExpression<QS, ST, DB> where
     ST: NativeSqlType,
-    T: Expression + SelectableExpression<QS, ST> + NonAggregate + QueryFragment,
+    DB: Backend,
+    Self: Expression,
+    Self: SelectableExpression<QS, ST>,
+    Self: NonAggregate,
+    Self: QueryFragment<DB>,
+{}
+
+impl<QS, T, ST, DB> BoxableExpression<QS, ST, DB> for T where
+    ST: NativeSqlType,
+    DB: Backend,
+    T: Expression,
+    T: SelectableExpression<QS, ST>,
+    T: NonAggregate,
+    T: QueryFragment<DB>,
 {
 }

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -1,3 +1,4 @@
+use backend::Backend;
 use expression::{Expression, SelectableExpression, NonAggregate};
 use query_builder::*;
 use types::IntoNullable;
@@ -17,10 +18,11 @@ impl<T> Expression for Nullable<T> where
     type SqlType = <<T as Expression>::SqlType as IntoNullable>::Nullable;
 }
 
-impl<T> QueryFragment for Nullable<T> where
-    T: QueryFragment,
+impl<T, DB> QueryFragment<DB> for Nullable<T> where
+    DB: Backend,
+    T: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         self.0.to_sql(out)
     }
 }

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -1,3 +1,4 @@
+use backend::Backend;
 use expression::{Expression, SelectableExpression, NonAggregate};
 use query_builder::*;
 use types;
@@ -26,11 +27,12 @@ macro_rules! numeric_operation {
             type SqlType = <Lhs::SqlType as types::ops::$name>::Output;
         }
 
-        impl<Lhs, Rhs> QueryFragment for $name<Lhs, Rhs> where
-            Lhs: QueryFragment,
-            Rhs: QueryFragment,
+        impl<Lhs, Rhs, DB> QueryFragment<DB> for $name<Lhs, Rhs> where
+            DB: Backend,
+            Lhs: QueryFragment<DB>,
+            Rhs: QueryFragment<DB>,
         {
-            fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+            fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
                 try!(self.lhs.to_sql(out));
                 out.push_sql($op);
                 self.rhs.to_sql(out)

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -1,3 +1,4 @@
+use backend::Backend;
 use query_builder::*;
 use std::marker::PhantomData;
 use super::{Expression, SelectableExpression, NonAggregate};
@@ -25,8 +26,8 @@ impl<ST: NativeSqlType> Expression for SqlLiteral<ST> {
     type SqlType = ST;
 }
 
-impl<ST> QueryFragment for SqlLiteral<ST> {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+impl<ST, DB: Backend> QueryFragment<DB> for SqlLiteral<ST> {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_sql(&self.sql);
         Ok(())
     }

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -3,6 +3,7 @@
 //! found in the README.
 #![deny(warnings)]
 #![cfg_attr(feature = "unstable", feature(time2))]
+pub mod backend;
 pub mod expression;
 #[doc(hidden)]
 pub mod persistable;

--- a/diesel/src/query_builder/clause_macro.rs
+++ b/diesel/src/query_builder/clause_macro.rs
@@ -1,12 +1,13 @@
 macro_rules! simple_clause {
     ($no_clause:ident, $clause:ident, $sql:expr) => {
+        use backend::Backend;
         use super::{QueryFragment, QueryBuilder, BuildQueryResult};
 
         #[derive(Debug, Clone, Copy)]
         pub struct $no_clause;
 
-        impl QueryFragment for $no_clause {
-            fn to_sql(&self, _out: &mut QueryBuilder) -> BuildQueryResult {
+        impl<DB: Backend> QueryFragment<DB> for $no_clause {
+            fn to_sql(&self, _out: &mut DB::QueryBuilder) -> BuildQueryResult {
                 Ok(())
             }
         }
@@ -14,10 +15,11 @@ macro_rules! simple_clause {
         #[derive(Debug, Clone, Copy)]
         pub struct $clause<Expr>(pub Expr);
 
-        impl<Expr> QueryFragment for $clause<Expr> where
-            Expr: QueryFragment,
+        impl<Expr, DB> QueryFragment<DB> for $clause<Expr> where
+            DB: Backend,
+            Expr: QueryFragment<DB>,
         {
-            fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+            fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
                 out.push_sql($sql);
                 self.0.to_sql(out)
             }

--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -1,3 +1,4 @@
+use backend::Backend;
 use query_builder::*;
 
 pub struct DeleteStatement<T>(T);
@@ -9,12 +10,13 @@ impl<T> DeleteStatement<T> {
     }
 }
 
-impl<T> QueryFragment for DeleteStatement<T> where
+impl<T, DB> QueryFragment<DB> for DeleteStatement<T> where
+    DB: Backend,
     T: UpdateTarget,
-    T::WhereClause: QueryFragment,
-    T::FromClause: QueryFragment,
+    T::WhereClause: QueryFragment<DB>,
+    T::FromClause: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_context(Context::Delete);
         out.push_sql("DELETE FROM ");
         try!(self.0.from_clause().to_sql(out));

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -1,5 +1,5 @@
 use expression::Expression;
-use super::{UpdateTarget, IncompleteUpdateStatement, IncompleteInsertStatement, SelectStatement, QueryFragment};
+use super::{UpdateTarget, IncompleteUpdateStatement, IncompleteInsertStatement, SelectStatement};
 use super::delete_statement::DeleteStatement;
 
 /// Creates an update statement. Helpers for updating a single row can be
@@ -26,9 +26,9 @@ use super::delete_statement::DeleteStatement;
 /// # fn main() {
 /// #     use self::users::dsl::*;
 /// #     let connection = establish_connection();
-/// let command = diesel::update(users.filter(id.eq(1)))
-///     .set(name.eq("James"));
-/// let updated_row = connection.query_one(command);
+/// let updated_row = diesel::update(users.filter(id.eq(1)))
+///     .set(name.eq("James"))
+///     .get_result(&connection);
 /// // When passed to `query_one`, the update statement will gain `RETURNING *`
 /// assert_eq!(Ok((1, "James".to_string())), updated_row);
 /// # }
@@ -112,7 +112,7 @@ pub fn insert<T>(records: T) -> IncompleteInsertStatement<T> {
 /// testing diesel itself, but likely useful for third party crates as well. The
 /// given expressions must be selectable from anywhere.
 pub fn select<T>(expression: T) -> SelectStatement<T::SqlType, T, ()> where
-    T: Expression + QueryFragment,
+    T: Expression,
 {
     SelectStatement::simple(expression, ())
 }

--- a/diesel/src/query_builder/nodes/mod.rs
+++ b/diesel/src/query_builder/nodes/mod.rs
@@ -1,9 +1,10 @@
+use backend::Backend;
 use query_builder::{QueryBuilder, BuildQueryResult, QueryFragment};
 
 pub struct Identifier<'a>(pub &'a str);
 
-impl<'a> QueryFragment for Identifier<'a> {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+impl<'a, DB: Backend> QueryFragment<DB> for Identifier<'a> {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_identifier(self.0)
     }
 }
@@ -45,13 +46,14 @@ impl<T, U, UU, V, VV, W, WW> CombinedJoin<Join<U, UU, VV, WW>> for Join<T, U, V,
     }
 }
 
-impl<T, U, V, W> QueryFragment for Join<T, U, V, W> where
-    T: QueryFragment,
-    U: QueryFragment,
-    V: QueryFragment,
-    W: QueryFragment,
+impl<T, U, V, W, DB> QueryFragment<DB> for Join<T, U, V, W> where
+    DB: Backend,
+    T: QueryFragment<DB>,
+    U: QueryFragment<DB>,
+    V: QueryFragment<DB>,
+    W: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         try!(self.lhs.to_sql(out));
         try!(self.join_type.to_sql(out));
         out.push_sql(" JOIN ");
@@ -78,11 +80,12 @@ impl<'a, T, U> InfixNode<'a, T, U> {
     }
 }
 
-impl<'a, T, U> QueryFragment for InfixNode<'a, T, U> where
-    T: QueryFragment,
-    U: QueryFragment,
+impl<'a, T, U, DB> QueryFragment<DB> for InfixNode<'a, T, U> where
+    DB: Backend,
+    T: QueryFragment<DB>,
+    U: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         try!(self.lhs.to_sql(out));
         out.push_sql(self.middle);
         try!(self.rhs.to_sql(out));

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -1,5 +1,6 @@
 mod dsl_impls;
 
+use backend::Backend;
 use expression::*;
 use query_source::*;
 use std::marker::PhantomData;
@@ -82,16 +83,17 @@ impl<ST, S, F, W, O, L, Of> Expression for SelectStatement<ST, S, F, W, O, L, Of
     type SqlType = types::Array<ST>;
 }
 
-impl<ST, S, F, W, O, L, Of> QueryFragment for SelectStatement<ST, S, F, W, O, L, Of> where
-    S: QueryFragment,
+impl<ST, S, F, W, O, L, Of, DB> QueryFragment<DB> for SelectStatement<ST, S, F, W, O, L, Of> where
+    DB: Backend,
+    S: QueryFragment<DB>,
     F: QuerySource,
-    F::FromClause: QueryFragment,
-    W: QueryFragment,
-    O: QueryFragment,
-    L: QueryFragment,
-    Of: QueryFragment,
+    F::FromClause: QueryFragment<DB>,
+    W: QueryFragment<DB>,
+    O: QueryFragment<DB>,
+    L: QueryFragment<DB>,
+    Of: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_context(Context::Select);
         out.push_sql("SELECT ");
         try!(self.select.to_sql(out));
@@ -106,14 +108,15 @@ impl<ST, S, F, W, O, L, Of> QueryFragment for SelectStatement<ST, S, F, W, O, L,
     }
 }
 
-impl<ST, S, W, O, L, Of> QueryFragment for SelectStatement<ST, S, (), W, O, L, Of> where
-    S: QueryFragment,
-    W: QueryFragment,
-    O: QueryFragment,
-    L: QueryFragment,
-    Of: QueryFragment,
+impl<ST, S, W, O, L, Of, DB> QueryFragment<DB> for SelectStatement<ST, S, (), W, O, L, Of> where
+    DB: Backend,
+    S: QueryFragment<DB>,
+    W: QueryFragment<DB>,
+    O: QueryFragment<DB>,
+    L: QueryFragment<DB>,
+    Of: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_context(Context::Select);
         out.push_sql("SELECT ");
         try!(self.select.to_sql(out));

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -1,3 +1,4 @@
+use backend::Pg;
 use connection::{Connection, Cursor};
 use query_builder::{Query, QueryFragment, AsQuery};
 use query_source::Queryable;
@@ -7,7 +8,7 @@ use super::LimitDsl;
 /// Methods to execute a query given a connection. These are automatically implemented for the
 /// various query types.
 pub trait LoadDsl: AsQuery + Sized where
-    Self::Query: QueryFragment,
+    Self::Query: QueryFragment<Pg>,
 {
     /// Executes the given query, returning an `Iterator` over the returned
     /// rows.
@@ -24,7 +25,7 @@ pub trait LoadDsl: AsQuery + Sized where
     fn first<U>(self, conn: &Connection) -> QueryResult<U> where
         U: Queryable<<<Self as LimitDsl>::Output as Query>::SqlType>,
         Self: LimitDsl,
-        <Self as LimitDsl>::Output: QueryFragment,
+        <Self as LimitDsl>::Output: QueryFragment<Pg>,
     {
         conn.query_one(self.limit(1))
     }
@@ -48,11 +49,11 @@ pub trait LoadDsl: AsQuery + Sized where
 }
 
 impl<T: AsQuery> LoadDsl for T where
-    T::Query: QueryFragment,
+    T::Query: QueryFragment<Pg>,
 {
 }
 
-pub trait ExecuteDsl: QueryFragment + Sized {
+pub trait ExecuteDsl: Sized + QueryFragment<Pg> {
     /// Executes the given command, returning the number of rows affected. Used
     /// in conjunction with
     /// [`update`](../query_builder/fn.update.html) and
@@ -62,5 +63,5 @@ pub trait ExecuteDsl: QueryFragment + Sized {
     }
 }
 
-impl<T: QueryFragment> ExecuteDsl for T {
+impl<T: QueryFragment<Pg>> ExecuteDsl for T {
 }

--- a/diesel/src/query_source/filter.rs
+++ b/diesel/src/query_source/filter.rs
@@ -61,7 +61,7 @@ impl<Source, Predicate> QuerySource for FilteredQuerySource<Source, Predicate> w
 
 impl<Source, Predicate> UpdateTarget for FilteredQuerySource<Source, Predicate> where
     Source: UpdateTarget,
-    Predicate: SelectableExpression<Source, SqlType=Bool> + QueryFragment,
+    Predicate: SelectableExpression<Source, SqlType=Bool>,
 {
     type Table = Source::Table;
     type WhereClause = Predicate;

--- a/diesel_codegen/src/update.rs
+++ b/diesel_codegen/src/update.rs
@@ -93,6 +93,7 @@ fn changeset_impl(
 ) -> Option<P<ast::Item>> {
     let ref struct_name = model.ty;
     let pk = model.primary_key_name();
+    let table_name = options.table_name;
     let attrs_for_changeset = model.attrs.iter().filter(|a| a.column_name != pk)
         .collect::<Vec<_>>();
     let changeset_ty = cx.ty(span, ast::TyTup(
@@ -107,6 +108,7 @@ fn changeset_impl(
         impl<'a: 'update, 'update> ::diesel::query_builder::AsChangeset for
             &'update $struct_name
         {
+            type Target = $table_name::table;
             type Changeset = $changeset_ty;
 
             fn as_changeset(self) -> Self::Changeset {

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -4,6 +4,7 @@ mod ops;
 use schema::{connection, NewUser};
 use schema::users::dsl::*;
 use diesel::*;
+use diesel::backend::Backend;
 use diesel::query_builder::*;
 use diesel::expression::dsl::*;
 
@@ -89,8 +90,11 @@ impl<T: types::NativeSqlType> Expression for Arbitrary<T> {
     type SqlType = T;
 }
 
-impl<T: types::NativeSqlType> QueryFragment for Arbitrary<T> {
-    fn to_sql(&self, _out: &mut QueryBuilder) -> BuildQueryResult {
+impl<T, DB> QueryFragment<DB> for Arbitrary<T> where
+    T: types::NativeSqlType,
+    DB: Backend,
+{
+    fn to_sql(&self, _out: &mut DB::QueryBuilder) -> BuildQueryResult {
         Ok(())
     }
 }

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -1,5 +1,6 @@
 use schema::*;
 use diesel::*;
+use diesel::backend::Pg;
 
 #[test]
 fn filter_by_int_equality() {
@@ -268,7 +269,7 @@ sql_function!(lower, lower_t, (x: VarChar) -> VarChar);
 
 #[test]
 fn filter_by_boxed_predicate() {
-    fn by_name(name: &str) -> Box<BoxableExpression<users::table, types::Bool, SqlType=types::Bool>> {
+    fn by_name(name: &str) -> Box<BoxableExpression<users::table, types::Bool, Pg, SqlType=types::Bool>> {
         Box::new(lower(users::name).eq(name.to_string()))
     }
 

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1,5 +1,6 @@
 use schema::connection;
 use diesel::*;
+use diesel::backend::Pg;
 use diesel::types::*;
 
 #[test]
@@ -306,7 +307,7 @@ use diesel::query_builder::QueryFragment;
 fn query_to_sql_equality<T, U>(sql_str: &str, value: U) -> bool where
     T: NativeSqlType,
     U: AsExpression<T> + Debug + Clone,
-    U::Expression: SelectableExpression<(), T> + QueryFragment,
+    U::Expression: SelectableExpression<(), T> + QueryFragment<Pg>,
 {
     use diesel::expression::dsl::sql;
     let connection = connection();

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -10,13 +10,14 @@ pub use diesel::result::Error;
 pub use diesel::data_types::*;
 pub use diesel::types::{NativeSqlType, ToSql, Nullable, Array};
 
+use diesel::backend::Pg;
 use diesel::expression::AsExpression;
 use diesel::query_builder::QueryFragment;
 
 pub fn test_type_round_trips<ST, T>(value: T) -> bool where
     ST: NativeSqlType,
     T: AsExpression<ST> + Queryable<ST> + PartialEq + Clone + ::std::fmt::Debug,
-    <T as AsExpression<ST>>::Expression: SelectableExpression<()> + QueryFragment,
+    <T as AsExpression<ST>>::Expression: SelectableExpression<()> + QueryFragment<Pg>,
 {
     let connection = connection();
     let query = select(AsExpression::<ST>::as_expression(value.clone()));


### PR DESCRIPTION
This serves two primary purposes. The first is that we are generic over
the backend, which we were always going to need to do eventually -- if
for no other reason than to prevent certain expressions from compiling
when used with the wrong type of backend.

The second benefit is that we are no longer using trait objects for the
query builder, as we can now know a single concrete type that we have to
work with. This means that `QueryBuilder` no longer needs to be object
safe in order for `Expression` to be object safe. This also means that
we can remove the object safety constraints from `NativeSqlType` and
inline things like `IntoNullable`.

For the most part, the only other piece of code that had to change was
`Changeset`, as it also needed to become generic over the backend. I
think I can likely remove this in the future. Most of this would have
been easier with HKTs.