### PR TITLE
Remove the lifetime from the `PgQueryBuilder`

### DIFF
--- a/diesel/src/connection/raw.rs
+++ b/diesel/src/connection/raw.rs
@@ -1,0 +1,131 @@
+extern crate pq_sys;
+extern crate libc;
+
+use self::pq_sys::*;
+use std::ffi::{CString, CStr};
+use std::{str, ptr};
+
+use result::*;
+
+pub struct RawConnection {
+    internal_connection: *mut PGconn,
+}
+
+impl RawConnection {
+    pub fn establish(database_url: &str) -> ConnectionResult<Self> {
+        let connection_string = try!(CString::new(database_url));
+        let connection_ptr = unsafe { PQconnectdb(connection_string.as_ptr()) };
+        let connection_status = unsafe { PQstatus(connection_ptr) };
+
+        match connection_status {
+            CONNECTION_OK => {
+                Ok(RawConnection {
+                    internal_connection: connection_ptr,
+                })
+            }
+            _ => {
+                let message = last_error_message(connection_ptr);
+                Err(ConnectionError::BadConnection(message))
+            }
+        }
+    }
+
+    pub fn last_error_message(&self) -> String {
+        last_error_message(self.internal_connection)
+    }
+
+    pub fn escape_identifier(&self, identifier: &str) -> QueryResult<PgString> {
+        let result_ptr = unsafe { PQescapeIdentifier(
+            self.internal_connection,
+            identifier.as_ptr() as *const libc::c_char,
+            identifier.len() as libc::size_t,
+        ) };
+
+        if result_ptr.is_null() {
+            Err(Error::DatabaseError(last_error_message(self.internal_connection)))
+        } else {
+            unsafe {
+                Ok(PgString::new(result_ptr))
+            }
+        }
+    }
+
+    pub fn set_notice_processor(&self, notice_processor: NoticeProcessor) {
+        unsafe {
+            PQsetNoticeProcessor(self.internal_connection, Some(notice_processor), ptr::null_mut());
+        }
+    }
+
+    pub unsafe fn exec(&self, query: *const libc::c_char) -> *mut PGresult {
+        PQexec(self.internal_connection, query)
+    }
+
+    pub unsafe fn exec_params(
+        &self,
+        query: *const libc::c_char,
+        param_count: libc::c_int,
+        param_types: *const Oid,
+        param_values: *const *const libc::c_char,
+        param_lengths: *const libc::c_int,
+        param_formats: *const libc::c_int,
+        result_format: libc::c_int,
+    ) -> *mut PGresult {
+        PQexecParams(
+            self.internal_connection,
+            query,
+            param_count,
+            param_types,
+            param_values,
+            param_lengths,
+            param_formats,
+            result_format,
+        )
+    }
+}
+
+pub type NoticeProcessor = extern "C" fn(arg: *mut libc::c_void, message: *const libc::c_char);
+
+impl Drop for RawConnection {
+    fn drop(&mut self) {
+        unsafe { PQfinish(self.internal_connection) };
+    }
+}
+
+fn last_error_message(conn: *const PGconn) -> String {
+    unsafe {
+        let error_ptr = PQerrorMessage(conn);
+        let bytes = CStr::from_ptr(error_ptr).to_bytes();
+        str::from_utf8_unchecked(bytes).to_string()
+    }
+}
+
+pub struct PgString {
+    pg_str: *mut libc::c_char,
+}
+
+impl PgString {
+    unsafe fn new(ptr: *mut libc::c_char) -> Self {
+        PgString {
+            pg_str: ptr,
+        }
+    }
+}
+
+impl ::std::ops::Deref for PgString {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        unsafe {
+            let c_string = CStr::from_ptr(self.pg_str);
+            str::from_utf8_unchecked(c_string.to_bytes())
+        }
+    }
+}
+
+impl Drop for PgString {
+    fn drop(&mut self) {
+        unsafe {
+            PQfreemem(self.pg_str as *mut libc::c_void)
+        }
+    }
+}

--- a/diesel/src/query_builder/pg.rs
+++ b/diesel/src/query_builder/pg.rs
@@ -1,9 +1,11 @@
-use connection::Connection;
+use std::rc::Rc;
+
+use connection::raw::RawConnection;
 use super::{QueryBuilder, Binds, BuildQueryResult, Context};
 use types::NativeSqlType;
 
-pub struct PgQueryBuilder<'a> {
-    conn: &'a Connection,
+pub struct PgQueryBuilder {
+    conn: Rc<RawConnection>,
     pub sql: String,
     pub binds: Binds,
     pub bind_types: Vec<u32>,
@@ -11,10 +13,10 @@ pub struct PgQueryBuilder<'a> {
     context_stack: Vec<Context>,
 }
 
-impl<'a> PgQueryBuilder<'a> {
-    pub fn new(conn: &'a Connection) -> Self {
+impl PgQueryBuilder {
+    pub fn new(conn: &Rc<RawConnection>) -> Self {
         PgQueryBuilder {
-            conn: conn,
+            conn: conn.clone(),
             sql: String::new(),
             binds: Vec::new(),
             bind_types: Vec::new(),
@@ -24,7 +26,7 @@ impl<'a> PgQueryBuilder<'a> {
     }
 }
 
-impl<'a> QueryBuilder for PgQueryBuilder<'a> {
+impl QueryBuilder for PgQueryBuilder {
     fn push_sql(&mut self, sql: &str) {
         self.sql.push_str(sql);
     }

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -27,9 +27,7 @@ fn test_count_star() {
     assert_eq!(Ok(1), source.first(&connection));
 
     // Ensure we're doing COUNT(*) instead of COUNT(table.*) which is going to be more efficient
-    let mut query_builder = ::diesel::query_builder::pg::PgQueryBuilder::new(&connection);
-    QueryFragment::to_sql(&source.as_query(), &mut query_builder).unwrap();
-    assert!(query_builder.sql.starts_with("SELECT COUNT(*) FROM"));
+    assert!(debug_sql!(source).starts_with("SELECT COUNT(*) FROM"));
 }
 
 use diesel::types::VarChar;


### PR DESCRIPTION
As we work to make `QueryFragment` generic over the backend, I would
prefer to not have a lifetime on the `Pg` backend. As such, that means
that `PgQueryBuilder` needs to have no associated lifetime. I don't want
to require that you put the actual connection in an `Rc`, but I do need
to pass something that isn't a reference to the query builder.

As such, I've isolated all methods that work with PQ directly into
another structure, which we keep inside of the `Connection`. This does
introduce a potential subtlety, which is that we are `Send` even though
we have a non-atomic reference counter. The reason this is safe is
because we *create* the `Rc` internally, and the only place we hand it
to anybody else is for a `query_builder`, which is only created in a
place that does not outlive a reference to the `Connection`. That means
that in order to send the `Connection`, you'd have to be in a context
where there are no other references to the `RawConnection`. However,
this is no longer enforced by the type system.