### PR TITLE
Hide `Cursor`, and just return a `Box<Iterator>` instead

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -71,7 +71,7 @@ pub mod prelude {
     pub use result::{QueryResult, TransactionError, TransactionResult, ConnectionError, ConnectionResult, OptionalExtension};
 }
 
-pub use connection::{Connection, Cursor};
+pub use connection::Connection;
 pub use prelude::*;
 #[doc(inline)]
 pub use query_builder::functions::{insert, update, delete, select};

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -1,4 +1,4 @@
-use connection::{Connection, Cursor};
+use connection::Connection;
 use query_builder::{Query, QueryFragment, AsQuery};
 use query_source::Queryable;
 use result::QueryResult;
@@ -11,8 +11,8 @@ pub trait LoadDsl: AsQuery + Sized where
 {
     /// Executes the given query, returning an `Iterator` over the returned
     /// rows.
-    fn load<U>(self, conn: &Connection) -> QueryResult<Cursor<Self::SqlType, U>> where
-        U: Queryable<Self::SqlType>
+    fn load<'a, U>(self, conn: &Connection) -> QueryResult<Box<Iterator<Item=U> + 'a>> where
+        U: Queryable<Self::SqlType> + 'a,
     {
         conn.query_all(self)
     }
@@ -40,8 +40,8 @@ pub trait LoadDsl: AsQuery + Sized where
     }
 
     /// Runs the command, returning an `Iterator` over the affected rows.
-    fn get_results<U>(self, conn: &Connection) -> QueryResult<Cursor<Self::SqlType, U>> where
-        U: Queryable<Self::SqlType>
+    fn get_results<'a, U>(self, conn: &Connection) -> QueryResult<Box<Iterator<Item=U> + 'a>> where
+        U: Queryable<Self::SqlType> + 'a,
     {
         self.load(conn)
     }

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -57,7 +57,7 @@ pub type BigSerial = BigInt;
 #[derive(Clone, Copy, Default)] pub struct Nullable<T: NativeSqlType + NotNull>(T);
 #[derive(Clone, Copy, Default)] pub struct Array<T: NativeSqlType>(T);
 
-pub trait NativeSqlType {
+pub trait NativeSqlType: 'static {
     fn oid(&self) -> u32;
     fn array_oid(&self) -> u32;
     fn new() -> Self where Self: Sized;

--- a/diesel_tests/tests/compile-fail/select_carries_correct_result_type_info.rs
+++ b/diesel_tests/tests/compile-fail/select_carries_correct_result_type_info.rs
@@ -19,8 +19,6 @@ fn main() {
 
     let ids: Vec<i32> = select_name.load(&connection).unwrap().collect();
     //~^ ERROR the trait `diesel::query_source::Queryable<diesel::types::VarChar>` is not implemented for the type `i32`
-    //~| ERROR E0277
     let names: Vec<String> = select_id.load(&connection).unwrap().collect();
     //~^ ERROR the trait `diesel::query_source::Queryable<diesel::types::Integer>` is not implemented
-    //~| ERROR E0277
 }

--- a/diesel_tests/tests/filter_operators.rs
+++ b/diesel_tests/tests/filter_operators.rs
@@ -125,9 +125,7 @@ trait TestResultHelpers<U> {
     fn as_vec(self) -> Vec<U>;
 }
 
-impl<ST, U> TestResultHelpers<U> for QueryResult<Cursor<ST, U>> where
-    Cursor<ST, U>: Iterator<Item=U>,
-{
+impl<U> TestResultHelpers<U> for QueryResult<Box<Iterator<Item=U>>> {
     fn as_vec(self) -> Vec<U> {
         self.unwrap().collect()
     }


### PR DESCRIPTION
This will allow us to abstract the `Connection` to be
non-backend-specific, without also having to do the same for `Cursor`.