### PR TITLE
Kill the hellish demon that is `Connection#find`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 rust:
   - stable
   - beta
-  - nightly-2016-01-15
+  - nightly-2016-01-23
   - nightly
 addons:
   postgresql: '9.4'

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -14,7 +14,7 @@ mod with_dsl;
 
 pub use self::belonging_to_dsl::BelongingToDsl;
 pub use self::count_dsl::CountDsl;
-pub use self::filter_dsl::FilterDsl;
+pub use self::filter_dsl::{FilterDsl, FindDsl};
 pub use self::limit_dsl::LimitDsl;
 pub use self::load_dsl::{LoadDsl, ExecuteDsl};
 pub use self::offset_dsl::OffsetDsl;

--- a/diesel_tests/tests/compile-fail/cannot_mix_aggregate_and_non_aggregate_selects.rs
+++ b/diesel_tests/tests/compile-fail/cannot_mix_aggregate_and_non_aggregate_selects.rs
@@ -24,17 +24,4 @@ fn main() {
     //~| ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
 }

--- a/diesel_tests/tests/compile-fail/find_requires_correct_type.rs
+++ b/diesel_tests/tests/compile-fail/find_requires_correct_type.rs
@@ -18,7 +18,7 @@ table! {
 
 fn main() {
     let connection = PgConnection::establish("").unwrap();
-    let one = connection.find(int_primary_key::table, "1".to_string()).unwrap();
+    int_primary_key::table.find("1").first(&connection).unwrap();
     //~^ ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277
@@ -27,8 +27,12 @@ fn main() {
     //~| ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277
-    let string = connection.find(string_primary_key::table, 1).unwrap();
+    //~| ERROR E0277
+    //~| ERROR E0277
+    string_primary_key::table.find(1).first(&connection).unwrap();
     //~^ ERROR E0277
+    //~| ERROR E0277
+    //~| ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277

--- a/diesel_tests/tests/compile-fail/find_requires_correct_type.rs
+++ b/diesel_tests/tests/compile-fail/find_requires_correct_type.rs
@@ -19,24 +19,11 @@ table! {
 fn main() {
     let connection = PgConnection::establish("").unwrap();
     int_primary_key::table.find("1").first(&connection).unwrap();
-    //~^ ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
+    //~^ ERROR no method named `first` found for type `diesel::query_source::filter::FilteredQuerySource<int_primary_key::table, diesel::expression::predicates::Eq<int_primary_key::columns::id, &str>>` in the current scope
     //~| ERROR E0277
     //~| ERROR E0277
     string_primary_key::table.find(1).first(&connection).unwrap();
-    //~^ ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
+    //~^ ERROR no method named `first` found for type `diesel::query_source::filter::FilteredQuerySource<string_primary_key::table, diesel::expression::predicates::Eq<string_primary_key::columns::id, _>>` in the current scope
     //~| ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277

--- a/diesel_tests/tests/compile-fail/select_requires_column_from_same_table.rs
+++ b/diesel_tests/tests/compile-fail/select_requires_column_from_same_table.rs
@@ -28,17 +28,4 @@ fn main() {
     //~| ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
 }

--- a/diesel_tests/tests/compile-fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
+++ b/diesel_tests/tests/compile-fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
@@ -29,34 +29,8 @@ fn main() {
     //~| ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     let stuff = users::table.select((posts::id, users::name));
     //~^ ERROR Selectable
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277

--- a/diesel_tests/tests/find.rs
+++ b/diesel_tests/tests/find.rs
@@ -10,9 +10,9 @@ fn find() {
     connection.execute("INSERT INTO users (id, name) VALUES (1, 'Sean'), (2, 'Tess')")
         .unwrap();
 
-    assert_eq!(Ok(User::new(1, "Sean")), connection.find(users, 1));
-    assert_eq!(Ok(User::new(2, "Tess")), connection.find(users, 2));
-    assert_eq!(Ok(None::<User>), connection.find(users, 3).optional());
+    assert_eq!(Ok(User::new(1, "Sean")), users.find(1).first(&connection));
+    assert_eq!(Ok(User::new(2, "Tess")), users.find(2).first(&connection));
+    assert_eq!(Ok(None::<User>), users.find(3).first(&connection).optional());
 }
 
 table! {
@@ -31,7 +31,7 @@ fn find_with_non_serial_pk() {
     connection.execute("INSERT INTO users_with_name_pk (name) VALUES ('Sean'), ('Tess')")
         .unwrap();
 
-    assert_eq!(Ok("Sean".to_string()), connection.find(users, "Sean"));
-    assert_eq!(Ok("Tess".to_string()), connection.find(users, "Tess".to_string()));
-    assert_eq!(Ok(None::<String>), connection.find(users, "Wibble").optional());
+    assert_eq!(Ok("Sean".to_string()), users.find("Sean").first(&connection));
+    assert_eq!(Ok("Tess".to_string()), users.find("Tess".to_string()).first(&connection));
+    assert_eq!(Ok(None::<String>), users.find("Wibble").first(&connection).optional());
 }

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -66,7 +66,7 @@ fn test_updating_multiple_columns() {
     )).execute(&connection).unwrap();
 
     let expected_user = User::with_hair_color(sean.id, "Jim", "black");
-    let user = connection.find(users, sean.id);
+    let user = users.find(sean.id).first(&connection);
     assert_eq!(Ok(expected_user), user);
 }
 
@@ -122,7 +122,7 @@ fn save_on_struct_with_primary_key_changes_that_struct() {
     let sean = find_user_by_name("Sean", &connection);
     let user = User::with_hair_color(sean.id, "Jim", "blue").save_changes::<User, _>(&connection);
 
-    let user_in_db = connection.find(users, sean.id);
+    let user_in_db = users.find(sean.id).first(&connection);
 
     assert_eq!(user, user_in_db);
 }
@@ -224,7 +224,7 @@ fn struct_with_option_fields_treated_as_null() {
     let changes = UpdatePost { id: post.id, title: "Hello again".into(), body: None };
     let expected_post = Post::new(post.id, sean.id, "Hello again".into(), None);
     let updated_post = changes.save_changes(&connection);
-    let post_in_database = connection.find(posts::table, post.id);
+    let post_in_database = posts::table.find(post.id).first(&connection);
 
     assert_eq!(Ok(&expected_post), updated_post.as_ref());
     assert_eq!(Ok(&expected_post), post_in_database.as_ref());


### PR DESCRIPTION
Let's be honest here. Nobody has seen a where clause in Rust than this.
It has become ridiculous, and in the past week, just about every
substantial commit I've made has caused it to become more ridiculous.

This is the *only* method on `Connection` not related to transactions
(which -- correct me if I'm wrong -- will always need to be methods on
`Connection`). This came out of a time where `query.load(&connection)`
was `connection.query_all(&query)`. This method is inconsistent, and in
our documentation is just ridiculous. Please, let's kill it.

The replacement for this method does not implicitly add `limit(1)`. If
you call `.get_result`, instead of `.first`, there's no actual guarantee
that the result set it's operating on contains only a single row.
However, given that this method filters on equality for a primary key, I
think this is low risk.

I honestly couldn't remember why I added this method at all. For those
curious, it was added in 0104863, and the reasoning was "It was easier
to implement than `filter` at the time". This was commit number 42,
which clearly means it is in fact the meaning of Rust, Diesel, and
everything, but it's time for it to go.

Also the original implementation included `let sql = sql + &format!("
WHERE {} = $1 LIMIT 1", source.primary_key().name());` which I find
completely hilarious. Ah ancient Diesel, your code was once so bad...