### PR TITLE
Add `SUM` and `AVG` functions

### DIFF
--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -1,0 +1,56 @@
+use backend::Backend;
+use expression::{Expression, SelectableExpression};
+use query_builder::*;
+use types::{Foldable, HasSqlType};
+
+macro_rules! fold_function {
+    ($fn_name:ident, $type_name:ident, $operator:expr, $docs:expr) => {
+        #[doc=$docs]
+        pub fn $fn_name<ST, T>(t: T) -> $type_name<T> where
+            ST: Foldable,
+            T: Expression<SqlType=ST>,
+        {
+            $type_name {
+                target: t,
+            }
+        }
+
+        #[derive(Debug, Clone, Copy)]
+        pub struct $type_name<T> {
+            target: T,
+        }
+
+        impl<ST, T> Expression for $type_name<T> where
+            ST: Foldable,
+            T: Expression<SqlType=ST>
+        {
+            type SqlType = <<T as Expression>::SqlType as Foldable>::$type_name;
+        }
+
+        impl<T, DB> QueryFragment<DB> for $type_name<T> where
+            T: Expression + QueryFragment<DB>,
+            DB: Backend + HasSqlType<T::SqlType>,
+        {
+            fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+                out.push_sql(concat!($operator, "("));
+                try!(self.target.to_sql(out));
+                out.push_sql(")");
+                Ok(())
+            }
+        }
+
+        impl<ST, T, QS> SelectableExpression<QS> for $type_name<T> where
+            ST: Foldable,
+            T: Expression<SqlType=ST>,
+        {
+        }
+    }
+}
+
+fold_function!(sum, Sum, "SUM",
+"Represents a SQL `SUM` function. This function can only take types which are
+Foldable.");
+
+fold_function!(avg, Avg, "AVG",
+"Represents a SQL `AVG` function. This function can only take types which are
+Foldable.");

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -158,4 +158,5 @@ macro_rules! no_arg_sql_function {
 }
 
 pub mod aggregate_ordering;
+pub mod aggregate_folding;
 pub mod date_and_time;

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -48,6 +48,7 @@ pub mod dsl {
     #[doc(inline)] pub use super::count::{count, count_star};
     #[doc(inline)] pub use super::functions::date_and_time::*;
     #[doc(inline)] pub use super::functions::aggregate_ordering::*;
+    #[doc(inline)] pub use super::functions::aggregate_folding::*;
     #[doc(inline)] pub use super::sql_literal::sql;
 
     pub use super::extensions::*;

--- a/diesel/src/types/fold.rs
+++ b/diesel/src/types/fold.rs
@@ -1,0 +1,38 @@
+use types::{self, NotNull};
+
+pub trait Foldable {
+    type Sum;
+    type Avg;
+}
+
+impl<T> Foldable for types::Nullable<T> where
+    T: Foldable + NotNull,
+    T::Sum: NotNull,
+    T::Avg: NotNull,
+{
+    type Sum = types::Nullable<T::Sum>;
+    type Avg = types::Nullable<T::Avg>;
+}
+
+macro_rules! foldable_impls {
+    ($($Source:ty => ($SumType:ty, $AvgType:ty)),+,) => {
+        $(
+            impl Foldable for $Source {
+                type Sum = $SumType;
+                type Avg = $AvgType;
+            }
+        )+
+    }
+}
+
+foldable_impls! {
+    types::SmallInt => (types::BigInt, types::Numeric),
+    types::Integer => (types::BigInt, types::Numeric),
+    types::BigInt => (types::Numeric, types::Numeric),
+
+    types::Float => (types::Float, types::Double),
+    types::Double => (types::Double, types::Double),
+    types::Numeric => (types::Numeric, types::Numeric),
+
+    types::Interval => (types::Interval, types::Interval),
+}

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -3,6 +3,7 @@
 pub mod ops;
 mod ord;
 mod impls;
+mod fold;
 
 #[doc(hidden)]
 pub mod structs {
@@ -17,6 +18,9 @@ pub mod structs {
 
 /// Marker trait for types which can be compared for ordering.
 pub use self::ord::SqlOrd;
+
+/// Marker trait for types which can be folded for a sum.
+pub use self::fold::Foldable;
 
 use backend::{Backend, TypeMetadata};
 use row::Row;

--- a/diesel_tests/tests/compile-fail/folding_functions_require_fold.rs
+++ b/diesel_tests/tests/compile-fail/folding_functions_require_fold.rs
@@ -1,0 +1,26 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+use diesel::expression::{sum, avg};
+
+table! {
+    time_key {
+        id -> Time,
+    }
+}
+
+table! {
+    string_primary_key {
+        id -> VarChar,
+    }
+}
+
+fn main() {
+    time_key::table.select(sum(time_key::id));
+    //~^ ERROR E0277
+    //~| ERROR E0277
+    string_primary_key::table.select(avg(string_primary_key::id));
+    //~^ ERROR E0277
+    //~| ERROR E0277
+}


### PR DESCRIPTION
Fixes #37

I decided to implement summing and averaging with one trait. If the `Money` DB type is implemented in the future, you can disable averaging for them by passing in `()` as the `Avg` type.