### PR TITLE
Make `FromSql` and `FromSqlRow` more generic over the backend

### DIFF
--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -19,6 +19,7 @@ pub trait Backend where
     Self: HasSqlType<types::Timestamp>,
 {
     type QueryBuilder: QueryBuilder<Self>;
+    type RawValue: ?Sized;
 }
 
 pub trait TypeMetadata {
@@ -29,6 +30,7 @@ pub struct Debug;
 
 impl Backend for Debug {
     type QueryBuilder = DebugQueryBuilder;
+    type RawValue = ();
 }
 
 impl TypeMetadata for Debug {
@@ -45,6 +47,7 @@ pub struct PgTypeMetadata {
 
 impl Backend for Pg {
     type QueryBuilder = PgQueryBuilder;
+    type RawValue = [u8];
 }
 
 impl TypeMetadata for Pg {

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -1,7 +1,8 @@
+use backend::{Backend, Pg};
 use db_result::PgResult;
 
-pub trait Row {
-    fn take(&mut self) -> Option<&[u8]>;
+pub trait Row<DB: Backend> {
+    fn take(&mut self) -> Option<&DB::RawValue>;
     fn next_is_null(&self, count: usize) -> bool;
 }
 
@@ -21,7 +22,7 @@ impl<'a> PgRow<'a> {
     }
 }
 
-impl<'a> Row for PgRow<'a> {
+impl<'a> Row<Pg> for PgRow<'a> {
     fn take(&mut self) -> Option<&[u8]> {
         let current_idx = self.col_idx;
         self.col_idx += 1;

--- a/diesel/src/types/impls/array.rs
+++ b/diesel/src/types/impls/array.rs
@@ -67,7 +67,7 @@ impl<T, ST> FromSqlRow<Array<ST>, Pg> for Vec<T> where
     Pg: HasSqlType<ST>,
     Vec<T>: FromSql<Array<ST>, Pg>,
 {
-    fn build_from_row<R: Row>(row: &mut R) -> Result<Self, Box<Error>> {
+    fn build_from_row<R: Row<Pg>>(row: &mut R) -> Result<Self, Box<Error>> {
         FromSql::<Array<ST>, Pg>::from_sql(row.take())
     }
 }

--- a/diesel/src/types/impls/floats/mod.rs
+++ b/diesel/src/types/impls/floats/mod.rs
@@ -1,7 +1,7 @@
 extern crate byteorder;
 
 use std::error::Error;
-use std::io::Write;
+use std::io::prelude::*;
 
 use backend::Backend;
 use self::byteorder::{ReadBytesExt, WriteBytesExt, BigEndian};
@@ -11,7 +11,7 @@ use types::{self, FromSql, ToSql, IsNull};
 #[cfg(feature = "quickcheck")]
 mod quickcheck_impls;
 
-impl<DB: Backend> FromSql<types::Float, DB> for f32 {
+impl<DB: Backend<RawValue=[u8]>> FromSql<types::Float, DB> for f32 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error>> {
         let mut bytes = not_none!(bytes);
         bytes.read_f32::<BigEndian>().map_err(|e| Box::new(e) as Box<Error>)
@@ -26,7 +26,7 @@ impl<DB: Backend> ToSql<types::Float, DB> for f32 {
     }
 }
 
-impl<DB: Backend> FromSql<types::Double, DB> for f64 {
+impl<DB: Backend<RawValue=[u8]>> FromSql<types::Double, DB> for f64 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error>> {
         let mut bytes = not_none!(bytes);
         bytes.read_f64::<BigEndian>().map_err(|e| Box::new(e) as Box<Error>)

--- a/diesel/src/types/impls/integers.rs
+++ b/diesel/src/types/impls/integers.rs
@@ -1,14 +1,14 @@
 extern crate byteorder;
 
 use std::error::Error;
-use std::io::Write;
+use std::io::prelude::*;
 
 use backend::{Backend, Pg};
 use self::byteorder::{ReadBytesExt, WriteBytesExt, BigEndian};
 use super::option::UnexpectedNullError;
 use types::{self, FromSql, ToSql, IsNull};
 
-impl<DB: Backend> FromSql<types::SmallInt, DB> for i16 {
+impl<DB: Backend<RawValue=[u8]>> FromSql<types::SmallInt, DB> for i16 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error>> {
         let mut bytes = not_none!(bytes);
         bytes.read_i16::<BigEndian>().map_err(|e| Box::new(e) as Box<Error>)
@@ -23,7 +23,7 @@ impl<DB: Backend> ToSql<types::SmallInt, DB> for i16 {
     }
 }
 
-impl<DB: Backend> FromSql<types::Integer, DB> for i32 {
+impl<DB: Backend<RawValue=[u8]>> FromSql<types::Integer, DB> for i32 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error>> {
         let mut bytes = not_none!(bytes);
         bytes.read_i32::<BigEndian>().map_err(|e| Box::new(e) as Box<Error>)
@@ -38,7 +38,7 @@ impl<DB: Backend> ToSql<types::Integer, DB> for i32 {
     }
 }
 
-impl<DB: Backend> FromSql<types::BigInt, DB> for i64 {
+impl<DB: Backend<RawValue=[u8]>> FromSql<types::BigInt, DB> for i64 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error>> {
         let mut bytes = not_none!(bytes);
         bytes.read_i64::<BigEndian>().map_err(|e| Box::new(e) as Box<Error>)

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -63,7 +63,7 @@ macro_rules! queryable_impls {
             DB: $crate::backend::Backend + $crate::types::HasSqlType<types::$Source>,
             $Target: $crate::types::FromSql<types::$Source, DB>,
         {
-            fn build_from_row<R: $crate::row::Row>(row: &mut R) -> Result<Self, Box<Error>> {
+            fn build_from_row<R: $crate::row::Row<DB>>(row: &mut R) -> Result<Self, Box<Error>> {
                 $crate::types::FromSql::<types::$Source, DB>::from_sql(row.take())
             }
         }
@@ -73,7 +73,7 @@ macro_rules! queryable_impls {
             DB: $crate::backend::Backend + $crate::types::HasSqlType<types::$Source>,
             Option<$Target>: $crate::types::FromSql<types::Nullable<types::$Source>, DB>,
         {
-            fn build_from_row<R: $crate::row::Row>(row: &mut R) -> Result<Self, Box<Error>> {
+            fn build_from_row<R: $crate::row::Row<DB>>(row: &mut R) -> Result<Self, Box<Error>> {
                 $crate::types::FromSql::<types::Nullable<types::$Source>, DB>::from_sql(row.take())
             }
         }

--- a/diesel/src/types/impls/option.rs
+++ b/diesel/src/types/impls/option.rs
@@ -20,7 +20,7 @@ impl<T, ST, DB> FromSql<Nullable<ST>, DB> for Option<T> where
     T: FromSql<ST, DB>,
     DB: Backend + HasSqlType<ST>, ST: NotNull,
 {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error>> {
+    fn from_sql(bytes: Option<&DB::RawValue>) -> Result<Self, Box<Error>> {
         match bytes {
             Some(_) => T::from_sql(bytes).map(Some),
             None => Ok(None)

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -38,7 +38,7 @@ macro_rules! tuple_impls {
                 $(DB: HasSqlType<$ST>),+,
                 DB: HasSqlType<($($ST,)+)>,
             {
-                fn build_from_row<RowT: Row>(row: &mut RowT) -> Result<Self, Box<Error>> {
+                fn build_from_row<RowT: Row<DB>>(row: &mut RowT) -> Result<Self, Box<Error>> {
                     Ok(($(try!($T::build_from_row(row)),)+))
                 }
             }
@@ -49,7 +49,7 @@ macro_rules! tuple_impls {
                 $(DB: HasSqlType<$ST>),+,
                 DB: HasSqlType<($($ST,)+)>,
             {
-                fn build_from_row<RowT: Row>(row: &mut RowT) -> Result<Self, Box<Error>> {
+                fn build_from_row<RowT: Row<DB>>(row: &mut RowT) -> Result<Self, Box<Error>> {
                     if e!(row.next_is_null($Tuple)) {
                         Ok(None)
                     } else {

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -84,13 +84,13 @@ impl<T: NotNull> IntoNullable for Nullable<T> {
 /// How to deserialize a single field of a given type. The input will always be
 /// the binary representation, not the text.
 pub trait FromSql<A, DB: Backend + HasSqlType<A>>: Sized {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error>>;
+    fn from_sql(bytes: Option<&DB::RawValue>) -> Result<Self, Box<Error>>;
 }
 
 /// How to deserialize multiple fields, with a known type. This type is
 /// implemented for tuples of various sizes.
 pub trait FromSqlRow<A, DB: Backend + HasSqlType<A>>: Sized {
-    fn build_from_row<T: Row>(row: &mut T) -> Result<Self, Box<Error>>;
+    fn build_from_row<T: Row<DB>>(row: &mut T) -> Result<Self, Box<Error>>;
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -314,7 +314,7 @@ fn third_party_crates_can_add_new_types() {
     }
 
     impl FromSqlRow<MyInt, Pg> for i32 {
-        fn build_from_row<R: ::diesel::row::Row>(row: &mut R) -> Result<Self, Box<Error>> {
+        fn build_from_row<R: ::diesel::row::Row<Pg>>(row: &mut R) -> Result<Self, Box<Error>> {
             FromSql::<MyInt, Pg>::from_sql(row.take())
         }
     }


### PR DESCRIPTION
This allows each backend to provide a "value" type that is used by
`FromSql`. This is required for Sqlite support. While I can do some
semi-hacky nonsense to make Sqlite work with our current `ToSql`
structure, there's just no way I can make it work with our `FromSql`
structure.

Sqlite only returns c ints from its values, and there's no way I can
know at the row level the number of bytes that are needed for `FromSql`
for that specific sized integer.

This unfortunately means that we can no longer assume that all backends
provide `String: FromSql<VarChar, Self>`. We can bring this requirement
back by changing `String: FromSql<VarChar, Pg>` to something like `Pg:
CanDeserialize<VarChar, String>`. I'm unsure how this will interact with
coherence, and feels significanly less natural than the `NativeSqlType`
change that we made for this.

I will likely make a similar change for `ToSql` in the future to make
Sqlite work in a less hacky manner.