### PR TITLE
Make sure we only use `RETURNING` on backends that support it

### DIFF
--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -26,6 +26,8 @@ pub trait TypeMetadata {
     type TypeMetadata;
 }
 
+pub trait SupportsReturningClause {}
+
 pub struct Debug;
 
 impl Backend for Debug {
@@ -36,6 +38,8 @@ impl Backend for Debug {
 impl TypeMetadata for Debug {
     type TypeMetadata = ();
 }
+
+impl SupportsReturningClause for Debug {}
 
 pub struct Pg;
 
@@ -53,3 +57,5 @@ impl Backend for Pg {
 impl TypeMetadata for Pg {
     type TypeMetadata = PgTypeMetadata;
 }
+
+impl SupportsReturningClause for Pg {}

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -1,4 +1,4 @@
-use backend::Backend;
+use backend::{Backend, SupportsReturningClause};
 use persistable::{Insertable, InsertableColumns};
 use expression::Expression;
 use query_builder::*;
@@ -83,7 +83,7 @@ impl<T, U> Query for InsertQuery<T, U> where
 }
 
 impl<T, U, DB> QueryFragment<DB> for InsertQuery<T, U> where
-    DB: Backend,
+    DB: Backend + SupportsReturningClause,
     T: QueryFragment<DB>,
     U: QueryFragment<DB>,
 {

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -4,7 +4,7 @@ pub mod target;
 pub use self::changeset::{Changeset, AsChangeset};
 pub use self::target::UpdateTarget;
 
-use backend::Backend;
+use backend::{Backend, SupportsReturningClause};
 use expression::Expression;
 use query_builder::{Query, AsQuery, QueryFragment, QueryBuilder, BuildQueryResult, Context};
 use query_source::Table;
@@ -75,7 +75,7 @@ impl<T, U> AsQuery for UpdateStatement<T, U> where
 pub struct UpdateQuery<T, U>(UpdateStatement<T, U>);
 
 impl<T, U, DB> QueryFragment<DB> for UpdateQuery<T, U> where
-    DB: Backend,
+    DB: Backend + SupportsReturningClause,
     T: UpdateTarget,
     <T::Table as Table>::AllColumns: QueryFragment<DB>,
     UpdateStatement<T, U>: QueryFragment<DB>,

--- a/diesel_codegen/src/update.rs
+++ b/diesel_codegen/src/update.rs
@@ -141,6 +141,7 @@ fn save_changes_impl(
                 $_pub fn save_changes<'update, T, Conn>(&'update self, connection: &Conn)
                     -> ::diesel::QueryResult<T> where
                     Conn::Backend: ::diesel::types::HasSqlType<$sql_type> +
+                        ::diesel::backend::SupportsReturningClause +
                         ::diesel::types::HasSqlType<
                             <<$table as ::diesel::query_source::Table>::PrimaryKey
                             as ::diesel::expression::Expression>::SqlType>,

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -41,8 +41,8 @@ fn filter_by_equality_on_nullable_columns() {
         NewUser::new("Tess", Some("brown")),
         NewUser::new("Jim", Some("black")),
     ];
-    let data: Vec<User> = insert(&data).into(users)
-        .get_results(&connection).unwrap().collect();;
+    insert(&data).into(users).execute(&connection).unwrap();
+    let data = users.load(&connection).unwrap().collect::<Vec<User>>();
     let sean = data[0].clone();
     let tess = data[1].clone();
     let jim = data[2].clone();
@@ -62,8 +62,8 @@ fn filter_by_is_not_null_on_nullable_columns() {
         NewUser::new("Derek", Some("red")),
         NewUser::new("Gordon", None),
     ];
-    let data: Vec<User> = insert(&data).into(users)
-        .get_results(&connection).unwrap().collect();
+    insert(&data).into(users).execute(&connection).unwrap();
+    let data = users.load(&connection).unwrap().collect::<Vec<User>>();
     let derek = data[0].clone();
 
     let source = users.filter(hair_color.is_not_null());
@@ -79,8 +79,8 @@ fn filter_by_is_null_on_nullable_columns() {
         NewUser::new("Derek", Some("red")),
         NewUser::new("Gordon", None),
     ];
-    let data: Vec<User> = insert(&data).into(users)
-        .get_results(&connection).unwrap().collect();
+    insert(&data).into(users).execute(&connection).unwrap();
+    let data = users.load(&connection).unwrap().collect::<Vec<User>>();
     let gordon = data[1].clone();
 
     let source = users.filter(hair_color.is_null());
@@ -151,8 +151,8 @@ fn filter_on_multiple_columns() {
         NewUser::new("Tess", Some("black")),
         NewUser::new("Tess", Some("brown")),
     ];
-    let data: Vec<User> = insert(data).into(users)
-        .get_results(&connection).unwrap().collect();
+    insert(data).into(users).execute(&connection).unwrap();
+    let data = users.load(&connection).unwrap().collect::<Vec<User>>();
     let black_haired_sean = data[0].clone();
     let brown_haired_sean = data[1].clone();
     let black_haired_tess = data[3].clone();
@@ -187,8 +187,8 @@ fn filter_called_twice_means_same_thing_as_and() {
         NewUser::new("Tess", Some("black")),
         NewUser::new("Tess", Some("brown")),
     ];
-    let data: Vec<User> = insert(data).into(users)
-        .get_results(&connection).unwrap().collect();
+    insert(data).into(users).execute(&connection).unwrap();
+    let data = users.load(&connection).unwrap().collect::<Vec<User>>();
     let black_haired_sean = data[0].clone();
     let brown_haired_sean = data[1].clone();
     let black_haired_tess = data[3].clone();

--- a/diesel_tests/tests/filter_operators.rs
+++ b/diesel_tests/tests/filter_operators.rs
@@ -91,8 +91,8 @@ fn filter_by_like() {
         NewUser::new("Tess Griffin", None),
         NewUser::new("Jim", None),
     ];
-    let data: Vec<User> = insert(&data).into(users)
-        .get_results(&connection).unwrap().collect();;
+    insert(&data).into(users).execute(&connection).unwrap();
+    let data = users.load(&connection).unwrap().collect::<Vec<User>>();
     let sean = data[0].clone();
     let tess = data[1].clone();
     let jim = data[2].clone();

--- a/diesel_tests/tests/order.rs
+++ b/diesel_tests/tests/order.rs
@@ -11,8 +11,8 @@ fn order_by_column() {
         NewUser::new("Tess", None),
         NewUser::new("Jim", None),
     ];
-    let data: Vec<User> =
-        insert(&data).into(users).get_results(&conn).unwrap().collect();
+    insert(&data).into(users).execute(&conn).unwrap();
+    let data = users.load(&conn).unwrap().collect::<Vec<User>>();
     let sean = &data[0];
     let tess = &data[1];
     let jim = &data[2];
@@ -25,8 +25,9 @@ fn order_by_column() {
     let data: Vec<_> = users.order(name).load(&conn).unwrap().collect();
     assert_eq!(expected_data, data);
 
-    let aaron = insert(&NewUser::new("Aaron", None)).into(users)
-        .get_result::<User>(&conn).unwrap();
+    insert(&NewUser::new("Aaron", None)).into(users)
+        .execute(&conn).unwrap();
+    let aaron = users.order(id.desc()).first::<User>(&conn).unwrap();
     let expected_data = vec![
         User::new(aaron.id, "Aaron"),
         User::new(jim.id, "Jim"),
@@ -47,8 +48,8 @@ fn order_by_descending_column() {
         NewUser::new("Tess", None),
         NewUser::new("Jim", None),
     ];
-    let data: Vec<User> = insert(&data).into(users)
-        .get_results(&conn).unwrap().collect();
+    insert(&data).into(users).execute(&conn).unwrap();
+    let data = users.load(&conn).unwrap().collect::<Vec<User>>();
     let sean = &data[0];
     let tess = &data[1];
     let jim = &data[2];
@@ -61,8 +62,9 @@ fn order_by_descending_column() {
     let data: Vec<_> = users.order(name.desc()).load(&conn).unwrap().collect();
     assert_eq!(expected_data, data);
 
-    let aaron = insert(&NewUser::new("Aaron", None)).into(users)
-        .get_result::<User>(&conn).unwrap();
+    insert(&NewUser::new("Aaron", None)).into(users)
+        .execute(&conn).unwrap();
+    let aaron = users.order(id.desc()).first::<User>(&conn).unwrap();
     let expected_data = vec![
         User::new(tess.id, "Tess"),
         User::new(sean.id, "Sean"),

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -137,11 +137,10 @@ fn selecting_columns_with_different_definition_order() {
     connection.execute("CREATE TABLE users (id SERIAL PRIMARY KEY, hair_color VARCHAR, name VARCHAR NOT NULL)")
         .unwrap();
     let expected_user = User::with_hair_color(1, "Sean", "black");
-    let user_from_insert = insert(&NewUser::new("Sean", Some("black"))).into(users::table)
-        .get_result(&connection);
+    insert(&NewUser::new("Sean", Some("black"))).into(users::table)
+        .execute(&connection).unwrap();
     let user_from_select = users::table.first(&connection);
 
-    assert_eq!(Ok(&expected_user), user_from_insert.as_ref());
     assert_eq!(Ok(&expected_user), user_from_select.as_ref());
 }
 


### PR DESCRIPTION
SQLite does not support RETURNING clauses. To my knowledge it is the
only backend that does not support it (though the syntax is different on
SQL Server).

Of course at the moment the only backend supported on master is PG,
which *does* support it. However, this was an extraction from the SQLite
branch that is able to live on its own. I've removed most uses of
`get_result` and `get_results` in tests, except for one explicit test
that returning clauses work (which is currently in a cfg attr which is
always true, but won't be once SQLite is merged).

There are still some places that it's being used which I need to track
down, but right now I've got those modules set to only run on PG anyway,
as they have other issues that require detangling from PG.