### PR TITLE
Implement `diesel database reset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Added `sum` and `avg` functions.
 
+* Added the `diesel setup`, `diesel database setup`, and `diesel database
+  reset` commands to the CLI.
+
 ### Changed
 
 * Rename both the `#[derive(Queriable)]` attribute and the `Queriable` trait to

--- a/diesel_cli/README.md
+++ b/diesel_cli/README.md
@@ -13,7 +13,8 @@ diesel setup --database-url='postgres://localhost/my_db'
 diesel migration generate create_users_table
 ```
 
-You'll see that two files were generated for you,
+You'll see that a `migrations/` directory was generated for you (by the setup
+command), and two sql files were generated,
 `migrations/{current_timestamp}_create_users_table/up.sql` and
 `migrations/{current_timestamp}_create_users_table/down.sql`. You should edit
 these files to show how to update your schema, and how to undo that change.
@@ -32,18 +33,18 @@ CREATE TABLE users (
 DROP TABLE USERS;
 ```
 
-You can then run your new migration by running `diesel migration run`. Make sure
-that you set the `DATABASE_URL` environment variable first, or pass it directly
-by doing `diesel migration run --database-url="postgres://localhost/your_database"`
-Alternatively, you can call
-[`diesel::migrations::run_pending_migrations`][pending-migrations] from
+You can then run your new migration by running `diesel migration run`. Make
+sure that you set the `DATABASE_URL` environment variable first, or pass it
+directly by doing `diesel migration run
+--database-url="postgres://localhost/your_database"` Alternatively, you can
+call [`diesel::migrations::run_pending_migrations`][pending-migrations] from
 `build.rs`.
 
 Diesel will automatically keep track of which migrations have already been run,
 ensuring that they're never run twice.
 
-### Commands
-#### `setup`
+## Commands
+## `diesel setup`
 Searches for a `migrations/` directory, and if it can't find one, creates one
 in the same directory as the first `Cargo.toml` it finds.  It then tries to
 connect to the provided DATABASE_URL, and will create the given database if it
@@ -51,6 +52,18 @@ cannot connect to it. Finally it will create diesel's internal table for
 tracking which migrations have been run, and run any existing migrations if the
 internal table did not previously exist.
 
+## `diesel database`
+#### `database setup`
+Tries to connect to the provided DATABASE_URL, and will create the given
+database if it cannot connect to it.  It then creates diesel's internal
+migrations tracking table if it needs to be created, and runs any pending
+migrations if it created the internal table.
+
+#### `database reset`
+Drops the database specified in your DATABASE_URL if it can, and then runs
+`database database setup`.
+
+## `diesel migration`
 #### `migration generate`
 Takes the name of your migration as an argument, and will create a migration
 directory with `migrations/` in the format of

--- a/diesel_cli/src/database_error.rs
+++ b/diesel_cli/src/database_error.rs
@@ -4,10 +4,10 @@ use std::convert::From;
 use std::{fmt, io};
 use std::error::Error;
 
-use self::SetupError::*;
+use self::DatabaseError::*;
 
 #[derive(Debug)]
-pub enum SetupError {
+pub enum DatabaseError {
     #[allow(dead_code)]
     CargoTomlNotFound,
     IoError(io::Error),
@@ -15,25 +15,25 @@ pub enum SetupError {
     ConnectionError(result::ConnectionError),
 }
 
-impl From<io::Error> for SetupError {
+impl From<io::Error> for DatabaseError {
     fn from(e: io::Error) -> Self {
         IoError(e)
     }
 }
 
-impl From<result::Error> for SetupError {
+impl From<result::Error> for DatabaseError {
     fn from(e: result::Error) -> Self {
         QueryError(e)
     }
 }
 
-impl From<result::ConnectionError> for SetupError {
+impl From<result::ConnectionError> for DatabaseError {
     fn from(e: result::ConnectionError) -> Self {
         ConnectionError(e)
     }
 }
 
-impl Error for SetupError {
+impl Error for DatabaseError {
     fn description(&self) -> &str {
         match *self {
             CargoTomlNotFound => "Unable to find Cargo.toml in this directory or any parent directories.",
@@ -44,13 +44,13 @@ impl Error for SetupError {
     }
 }
 
-impl fmt::Display for SetupError {
+impl fmt::Display for DatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         self.description().fmt(f)
     }
 }
 
-impl PartialEq for SetupError {
+impl PartialEq for DatabaseError {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (


### PR DESCRIPTION
This has a lot of changes because it does a few things at the same time:
* Changed most functions to take a generic Connection. This gets us a
little closer to making the CLI generic over the backend, and allows for
easier testing, as it gives us control over the connection it uses.

* Document more functions and add some messages to the user when
running setup/reset.

* Add the `diesel database reset` command, and move `diesel setup` to be
a subcommand of `diesel database`.