### PR TITLE
Allow the user to set the DATABASE_URL through dotenv

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["orm", "database", "postgres", "postgresql", "sql"]
 name = "diesel"
 
 [dependencies]
-diesel = "^0.4.0"
-clap = "^1.5.5"
 chrono = "^0.2.17"
+clap = "^1.5.5"
+diesel = "^0.4.0"
+dotenv = "^0.8.0"
 
 [dev-dependencies]
-dotenv = "^0.6.0"
 tempdir = "^0.3.4"

--- a/diesel_cli/README.md
+++ b/diesel_cli/README.md
@@ -33,17 +33,24 @@ CREATE TABLE users (
 DROP TABLE USERS;
 ```
 
-You can then run your new migration by running `diesel migration run`. Make
-sure that you set the `DATABASE_URL` environment variable first, or pass it
-directly by doing `diesel migration run
---database-url="postgres://localhost/your_database"` Alternatively, you can
-call [`diesel::migrations::run_pending_migrations`][pending-migrations] from
+You can then run your new migration by running `diesel migration run`. Your
+DATABASE_URL must be set in order to run this command, and there are serveral
+ways that you can set it:
+
+* Set it as an environment variable manually
+* Set it as an environment variable using [rust-dotenv][rust-dotenv]
+* Pass it directly by adding the `--database-url` flag
+
+As an alternative to running migrations with the CLI, you can call
+[`diesel::migrations::run_pending_migrations`][pending-migrations] from
 `build.rs`.
 
 Diesel will automatically keep track of which migrations have already been run,
 ensuring that they're never run twice.
 
-## Commands
+Commands
+--------
+
 ## `diesel setup`
 Searches for a `migrations/` directory, and if it can't find one, creates one
 in the same directory as the first `Cargo.toml` it finds.  It then tries to
@@ -81,3 +88,4 @@ Runs the `down.sql` for the most recent migration.
 Runs the `down.sql` and then the `up.sql` for the most recent migration.
 
 [pending-migrations]: http://sgrif.github.io/diesel/diesel/migrations/fn.run_pending_migrations.html
+[rust-dotenv]: https://github.com/slapresta/rust-dotenv#examples

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -2,6 +2,7 @@ extern crate chrono;
 #[macro_use]
 extern crate clap;
 extern crate diesel;
+extern crate dotenv;
 
 mod database_error;
 
@@ -247,6 +248,8 @@ fn handle_error<E: Error>(error: E) {
 }
 
 fn database_url(matches: &ArgMatches) -> String {
+    dotenv::dotenv().ok();
+
     matches.value_of("DATABASE_URL")
         .map(|s| s.into())
         .or(env::var("DATABASE_URL").ok())
@@ -262,8 +265,9 @@ fn connection(database_url: &str) -> PgConnection {
 #[cfg(test)]
 mod tests {
     extern crate diesel;
-    extern crate dotenv;
     extern crate tempdir;
+
+    use dotenv::dotenv;
 
     use self::tempdir::TempDir;
     use self::diesel::Connection;
@@ -278,7 +282,7 @@ mod tests {
     use std::{env, fs};
 
     fn database_url() -> String {
-        dotenv::dotenv().ok();
+        dotenv().ok();
         env::var("DATABASE_URL")
             .expect("DATABASE_URL must be set in order to run diesel_cli tests")
     }


### PR DESCRIPTION
This allows the user to set their DATABASE_URL for the diesel CLI in
their `.env` file.

I also took the chance to bump the dotenv version.