### PR TITLE
Disallow batch insert on SQLite

### DIFF
--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -29,6 +29,7 @@ pub trait TypeMetadata {
 }
 
 pub trait SupportsReturningClause {}
+pub trait SupportsDefaultKeyword {}
 
 pub struct Debug;
 
@@ -42,6 +43,7 @@ impl TypeMetadata for Debug {
 }
 
 impl SupportsReturningClause for Debug {}
+impl SupportsDefaultKeyword for Debug {}
 
 pub struct Pg;
 
@@ -61,6 +63,7 @@ impl TypeMetadata for Pg {
 }
 
 impl SupportsReturningClause for Pg {}
+impl SupportsDefaultKeyword for Pg {}
 
 pub struct Sqlite;
 

--- a/diesel/src/migrations/schema.rs
+++ b/diesel/src/migrations/schema.rs
@@ -12,7 +12,7 @@ use expression::grouped::Grouped;
 use expression::helper_types::AsExpr;
 use {Insertable, types};
 
-impl<'update: 'a, 'a> Insertable<__diesel_schema_migrations::table>
+impl<'update: 'a, 'a, DB> Insertable<__diesel_schema_migrations::table, DB>
 for &'update NewMigration<'a> {
     type Columns = __diesel_schema_migrations::version;
     type Values = Grouped<AsExpr<&'a str, Self::Columns>>;

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -39,7 +39,7 @@ impl<T, U, DB> QueryFragment<DB> for InsertStatement<T, U> where
     DB: Backend,
     T: Table,
     T::FromClause: QueryFragment<DB>,
-    U: Insertable<T> + Copy,
+    U: Insertable<T, DB> + Copy,
     U::Values: QueryFragment<DB>,
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {

--- a/diesel_codegen/src/insertable.rs
+++ b/diesel_codegen/src/insertable.rs
@@ -75,7 +75,7 @@ fn insertable_impl(
     let values_expr = values_expr(cx, span, table_mod, &fields);
 
     quote_item!(cx,
-        impl<'a: 'insert, 'insert> ::diesel::persistable::Insertable<$table_mod::table> for
+        impl<'a: 'insert, 'insert, DB> ::diesel::persistable::Insertable<$table_mod::table, DB> for
             &'insert $ty
         {
             type Columns = $columns_ty;

--- a/diesel_tests/tests/bench.rs
+++ b/diesel_tests/tests/bench.rs
@@ -25,7 +25,7 @@ fn bench_selecting_10k_rows_with_trivial_query(b: &mut Bencher) {
     let data: Vec<_> = (0..10_000).map(|i| {
         NewUser::new(&format!("User {}", i), None)
     }).collect();
-    insert(&data).into(users::table).execute(&conn).unwrap();
+    batch_insert(&data, users::table, &conn);
 
     b.iter(|| {
         users::table.load(&conn).unwrap().collect::<Vec<User>>()
@@ -53,7 +53,7 @@ fn bench_selecting_10k_rows_with_medium_complex_query(b: &mut Bencher) {
         let hair_color = if i % 2 == 0 { "black" } else { "brown" };
         NewUser::new(&format!("User {}", i), Some(hair_color))
     }).collect();
-    insert(&data).into(users::table).execute(&conn).unwrap();
+    batch_insert(&data, users::table, &conn);
 
     b.iter(|| {
         use schema::users::dsl::*;

--- a/diesel_tests/tests/compile-fail/batch_insert_is_not_supported_on_sqlite.rs
+++ b/diesel_tests/tests/compile-fail/batch_insert_is_not_supported_on_sqlite.rs
@@ -56,8 +56,12 @@ impl<'a> Insertable<users::table, Sqlite> for &'a NewUser {
 fn main() {
     let connection = SqliteConnection::establish(":memory:").unwrap();
 
-    insert(&NewUser("Hello".into()))
+    let new_users = vec![
+        NewUser("Hello".into()),
+        NewUser("World".into()),
+    ];
+    insert(&new_users)
         .into(users::table)
-        .get_result::<User>(&connection);
-    //~^ ERROR: SupportsReturningClause
+        .execute(&connection);
+    //~^ ERROR: SupportsDefaultKeyword
 }

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -1,7 +1,7 @@
 mod date_and_time;
 mod ops;
 
-use schema::{connection, NewUser};
+use schema::{connection, NewUser, batch_insert};
 use schema::users::dsl::*;
 use diesel::*;
 use diesel::backend::Backend;
@@ -74,7 +74,7 @@ fn max_returns_same_type_as_expression_being_maximized() {
         NewUser::new("C", None),
         NewUser::new("A", None),
     ];
-    insert(data).into(users).execute(&connection).unwrap();
+    batch_insert(data, users, &connection);
     assert_eq!(Ok("C".to_string()), source.first(&connection));
     connection.execute("DELETE FROM users WHERE name = 'C'").unwrap();
     assert_eq!(Ok("B".to_string()), source.first(&connection));

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -41,7 +41,7 @@ fn filter_by_equality_on_nullable_columns() {
         NewUser::new("Tess", Some("brown")),
         NewUser::new("Jim", Some("black")),
     ];
-    insert(&data).into(users).execute(&connection).unwrap();
+    batch_insert(&data, users, &connection);
     let data = users.load(&connection).unwrap().collect::<Vec<User>>();
     let sean = data[0].clone();
     let tess = data[1].clone();
@@ -62,7 +62,7 @@ fn filter_by_is_not_null_on_nullable_columns() {
         NewUser::new("Derek", Some("red")),
         NewUser::new("Gordon", None),
     ];
-    insert(&data).into(users).execute(&connection).unwrap();
+    batch_insert(&data, users, &connection);
     let data = users.load(&connection).unwrap().collect::<Vec<User>>();
     let derek = data[0].clone();
 
@@ -79,7 +79,7 @@ fn filter_by_is_null_on_nullable_columns() {
         NewUser::new("Derek", Some("red")),
         NewUser::new("Gordon", None),
     ];
-    insert(&data).into(users).execute(&connection).unwrap();
+    batch_insert(&data, users, &connection);
     let data = users.load(&connection).unwrap().collect::<Vec<User>>();
     let gordon = data[1].clone();
 
@@ -130,7 +130,7 @@ fn filter_then_select() {
 
     let connection = connection();
     let data = vec![NewUser::new("Sean", None), NewUser::new("Tess", None)];
-    insert(&data).into(users).execute(&connection).unwrap();
+    batch_insert(&data, users, &connection);
 
     assert_eq!(Ok("Sean".to_string()),
         users.filter(name.eq("Sean")).select(name).first(&connection));
@@ -152,7 +152,7 @@ fn filter_on_multiple_columns() {
         NewUser::new("Tess", Some("black")),
         NewUser::new("Tess", Some("brown")),
     ];
-    insert(data).into(users).execute(&connection).unwrap();
+    batch_insert(data, users, &connection);
     let data = users.load(&connection).unwrap().collect::<Vec<User>>();
     let black_haired_sean = data[0].clone();
     let brown_haired_sean = data[1].clone();
@@ -188,7 +188,7 @@ fn filter_called_twice_means_same_thing_as_and() {
         NewUser::new("Tess", Some("black")),
         NewUser::new("Tess", Some("brown")),
     ];
-    insert(data).into(users).execute(&connection).unwrap();
+    batch_insert(data, users, &connection);
     let data = users.load(&connection).unwrap().collect::<Vec<User>>();
     let black_haired_sean = data[0].clone();
     let brown_haired_sean = data[1].clone();

--- a/diesel_tests/tests/filter_operators.rs
+++ b/diesel_tests/tests/filter_operators.rs
@@ -91,7 +91,7 @@ fn filter_by_like() {
         NewUser::new("Tess Griffin", None),
         NewUser::new("Jim", None),
     ];
-    insert(&data).into(users).execute(&connection).unwrap();
+    batch_insert(&data, users, &connection);
     let data = users.load(&connection).unwrap().collect::<Vec<User>>();
     let sean = data[0].clone();
     let tess = data[1].clone();

--- a/diesel_tests/tests/order.rs
+++ b/diesel_tests/tests/order.rs
@@ -11,7 +11,7 @@ fn order_by_column() {
         NewUser::new("Tess", None),
         NewUser::new("Jim", None),
     ];
-    insert(&data).into(users).execute(&conn).unwrap();
+    batch_insert(&data, users, &conn);
     let data = users.load(&conn).unwrap().collect::<Vec<User>>();
     let sean = &data[0];
     let tess = &data[1];
@@ -48,7 +48,7 @@ fn order_by_descending_column() {
         NewUser::new("Tess", None),
         NewUser::new("Jim", None),
     ];
-    insert(&data).into(users).execute(&conn).unwrap();
+    batch_insert(&data, users, &conn);
     let data = users.load(&conn).unwrap().collect::<Vec<User>>();
     let sean = &data[0];
     let tess = &data[1];


### PR DESCRIPTION
Related to #157. Whether this functionality is eventually added back is
out of scope for 0.5. What is clear is that we need to fix the single
record case on SQLite, and that we cannot safely insert multiple records
in a single query on SQLite.

This does not fix the single record case, and does not resolve the
issue. However, the actual solution to that will be much more complex,
and this is comparatively simple -- and will be a pre-requisite for any
solution to the actual issue.