### PR TITLE
Fix inserting default values on SQLite

### DIFF
--- a/diesel/src/migrations/schema.rs
+++ b/diesel/src/migrations/schema.rs
@@ -7,21 +7,28 @@ table! {
 
 pub struct NewMigration<'a>(pub &'a str);
 
+use backend::Backend;
 use expression::AsExpression;
-use expression::grouped::Grouped;
 use expression::helper_types::AsExpr;
-use {Insertable, types};
+use persistable::{Insertable, ColumnInsertValue, InsertValues};
 
 impl<'update: 'a, 'a, DB> Insertable<__diesel_schema_migrations::table, DB>
-for &'update NewMigration<'a> {
-    type Columns = __diesel_schema_migrations::version;
-    type Values = Grouped<AsExpr<&'a str, Self::Columns>>;
-
-    fn columns() -> Self::Columns {
-        __diesel_schema_migrations::version
-    }
+    for &'update NewMigration<'a> where
+        DB: Backend,
+        (ColumnInsertValue<
+            __diesel_schema_migrations::version,
+            AsExpr<&'a str, __diesel_schema_migrations::version>,
+        >,): InsertValues<DB>,
+{
+    type Values = (ColumnInsertValue<
+        __diesel_schema_migrations::version,
+        AsExpr<&'a str, __diesel_schema_migrations::version>,
+    >,);
 
     fn values(self) -> Self::Values {
-        Grouped(AsExpression::<types::VarChar>::as_expression(self.0))
+        (ColumnInsertValue::Expression(
+            __diesel_schema_migrations::version,
+            AsExpression::<::types::VarChar>::as_expression(self.0),
+        ),)
     }
 }

--- a/diesel/src/query_builder/debug.rs
+++ b/diesel/src/query_builder/debug.rs
@@ -1,12 +1,11 @@
 use backend::Debug;
-use super::{QueryBuilder, BuildQueryResult, Context};
+use super::{QueryBuilder, BuildQueryResult};
 use types::HasSqlType;
 
 #[doc(hidden)]
 pub struct DebugQueryBuilder {
     pub sql: String,
     pub bind_types: Vec<u32>,
-    context_stack: Vec<Context>,
 }
 
 impl DebugQueryBuilder {
@@ -14,7 +13,6 @@ impl DebugQueryBuilder {
         DebugQueryBuilder {
             sql: String::new(),
             bind_types: Vec::new(),
-            context_stack: Vec::new(),
         }
     }
 }
@@ -31,20 +29,10 @@ impl QueryBuilder<Debug> for DebugQueryBuilder {
         Ok(())
     }
 
+    #[allow(unused_variables)]
     fn push_bound_value<T>(&mut self, bind: Option<Vec<u8>>) where
         Debug: HasSqlType<T>,
     {
-        match (self.context_stack.first(), bind) {
-            (Some(&Context::Insert), None) => self.push_sql("DEFAULT"),
-            _ => self.push_sql("?"),
-        }
-    }
-
-    fn push_context(&mut self, context: Context) {
-        self.context_stack.push(context);
-    }
-
-    fn pop_context(&mut self) {
-        self.context_stack.pop();
+        self.push_sql("?");
     }
 }

--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -17,14 +17,12 @@ impl<T, DB> QueryFragment<DB> for DeleteStatement<T> where
     T::FromClause: QueryFragment<DB>,
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        out.push_context(Context::Delete);
         out.push_sql("DELETE FROM ");
         try!(self.0.from_clause().to_sql(out));
         if let Some(clause) = self.0.where_clause() {
             out.push_sql(" WHERE ");
             try!(clause.to_sql(out));
         }
-        out.pop_context();
         Ok(())
     }
 }

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -1,5 +1,5 @@
 use backend::{Backend, SupportsReturningClause};
-use persistable::{Insertable, InsertableColumns};
+use persistable::{Insertable, InsertValues};
 use expression::Expression;
 use query_builder::*;
 use query_source::Table;
@@ -40,17 +40,15 @@ impl<T, U, DB> QueryFragment<DB> for InsertStatement<T, U> where
     T: Table,
     T::FromClause: QueryFragment<DB>,
     U: Insertable<T, DB> + Copy,
-    U::Values: QueryFragment<DB>,
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        out.push_context(Context::Insert);
+        let values = self.records.values();
         out.push_sql("INSERT INTO ");
         try!(self.target.from_clause().to_sql(out));
         out.push_sql(" (");
-        out.push_sql(&U::columns().names());
+        try!(values.column_names(out));
         out.push_sql(") VALUES ");
-        try!(QueryFragment::to_sql(&self.records.values(), out));
-        out.pop_context();
+        try!(values.values_clause(out));
         Ok(())
     }
 }
@@ -88,11 +86,9 @@ impl<T, U, DB> QueryFragment<DB> for InsertQuery<T, U> where
     U: QueryFragment<DB>,
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        out.push_context(Context::Insert);
         try!(self.statement.to_sql(out));
         out.push_sql(" RETURNING ");
         try!(self.returning.to_sql(out));
-        out.pop_context();
         Ok(())
     }
 }

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -45,19 +45,6 @@ pub trait QueryBuilder<DB: Backend> {
     fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult;
     fn push_bound_value<T>(&mut self, binds: Option<Vec<u8>>) where
         DB: HasSqlType<T>;
-    fn push_context(&mut self, context: Context);
-    fn pop_context(&mut self);
-}
-
-/// Represents the current overall type of query being constructed. Used for
-/// example, to place the keyword `DEFAULT` instead of a bind param when a null
-/// bind param is pushed on insert.
-#[derive(Debug, Clone, Copy)]
-pub enum Context {
-    Select,
-    Insert,
-    Update,
-    Delete,
 }
 
 /// A complete SQL query with a return type. This can be a select statement, or

--- a/diesel/src/query_builder/pg.rs
+++ b/diesel/src/query_builder/pg.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use backend::Pg;
 use connection::pg::raw::RawConnection;
-use super::{QueryBuilder, Binds, BuildQueryResult, Context};
+use super::{QueryBuilder, Binds, BuildQueryResult};
 use types::HasSqlType;
 
 pub struct PgQueryBuilder {
@@ -11,7 +11,6 @@ pub struct PgQueryBuilder {
     pub binds: Binds,
     pub bind_types: Vec<u32>,
     bind_idx: u32,
-    context_stack: Vec<Context>,
 }
 
 impl PgQueryBuilder {
@@ -22,7 +21,6 @@ impl PgQueryBuilder {
             binds: Vec::new(),
             bind_types: Vec::new(),
             bind_idx: 0,
-            context_stack: Vec::new(),
         }
     }
 }
@@ -40,23 +38,10 @@ impl QueryBuilder<Pg> for PgQueryBuilder {
     fn push_bound_value<T>(&mut self, bind: Option<Vec<u8>>) where
         Pg: HasSqlType<T>,
     {
-        match (self.context_stack.first(), bind) {
-            (Some(&Context::Insert), None) => self.push_sql("DEFAULT"),
-            (_, bind) => {
-                self.bind_idx += 1;
-                let sql = format!("${}", self.bind_idx);
-                self.push_sql(&sql);
-                self.binds.push(bind);
-                self.bind_types.push(Pg::metadata().oid);
-            }
-        }
-    }
-
-    fn push_context(&mut self, context: Context) {
-        self.context_stack.push(context);
-    }
-
-    fn pop_context(&mut self) {
-        self.context_stack.pop();
+        self.bind_idx += 1;
+        let sql = format!("${}", self.bind_idx);
+        self.push_sql(&sql);
+        self.binds.push(bind);
+        self.bind_types.push(Pg::metadata().oid);
     }
 }

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -4,7 +4,7 @@ use backend::Backend;
 use expression::*;
 use query_source::*;
 use std::marker::PhantomData;
-use super::{Query, QueryBuilder, QueryFragment, BuildQueryResult, Context};
+use super::{Query, QueryBuilder, QueryFragment, BuildQueryResult};
 use super::limit_clause::NoLimitClause;
 use super::offset_clause::NoOffsetClause;
 use super::order_clause::NoOrderClause;
@@ -92,7 +92,6 @@ impl<ST, S, F, W, O, L, Of, DB> QueryFragment<DB> for SelectStatement<ST, S, F, 
     Of: QueryFragment<DB>,
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        out.push_context(Context::Select);
         out.push_sql("SELECT ");
         try!(self.select.to_sql(out));
         out.push_sql(" FROM ");
@@ -101,7 +100,6 @@ impl<ST, S, F, W, O, L, Of, DB> QueryFragment<DB> for SelectStatement<ST, S, F, 
         try!(self.order.to_sql(out));
         try!(self.limit.to_sql(out));
         try!(self.offset.to_sql(out));
-        out.pop_context();
         Ok(())
     }
 }
@@ -115,14 +113,12 @@ impl<ST, S, W, O, L, Of, DB> QueryFragment<DB> for SelectStatement<ST, S, (), W,
     Of: QueryFragment<DB>,
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        out.push_context(Context::Select);
         out.push_sql("SELECT ");
         try!(self.select.to_sql(out));
         try!(self.where_clause.to_sql(out));
         try!(self.order.to_sql(out));
         try!(self.limit.to_sql(out));
         try!(self.offset.to_sql(out));
-        out.pop_context();
         Ok(())
     }
 }

--- a/diesel/src/query_builder/sqlite.rs
+++ b/diesel/src/query_builder/sqlite.rs
@@ -1,5 +1,5 @@
 use backend::{Sqlite, SqliteType};
-use super::{QueryBuilder, BuildQueryResult, Context};
+use super::{QueryBuilder, BuildQueryResult};
 use types::HasSqlType;
 
 #[doc(hidden)]
@@ -34,11 +34,5 @@ impl QueryBuilder<Sqlite> for SqliteQueryBuilder {
     {
         self.push_sql("?");
         self.bind_params.push((Sqlite::metadata(), bind));
-    }
-
-    fn push_context(&mut self, _context: Context) {
-    }
-
-    fn pop_context(&mut self) {
     }
 }

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -6,7 +6,7 @@ pub use self::target::UpdateTarget;
 
 use backend::{Backend, SupportsReturningClause};
 use expression::Expression;
-use query_builder::{Query, AsQuery, QueryFragment, QueryBuilder, BuildQueryResult, Context};
+use query_builder::{Query, AsQuery, QueryFragment, QueryBuilder, BuildQueryResult};
 use query_source::Table;
 
 /// The type returned by [`update`](fn.update.html). The only thing you can do
@@ -46,7 +46,6 @@ impl<T, U, DB> QueryFragment<DB> for UpdateStatement<T, U> where
     U: changeset::Changeset<DB>,
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        out.push_context(Context::Update);
         out.push_sql("UPDATE ");
         try!(self.target.from_clause().to_sql(out));
         out.push_sql(" SET ");
@@ -55,7 +54,6 @@ impl<T, U, DB> QueryFragment<DB> for UpdateStatement<T, U> where
             out.push_sql(" WHERE ");
             try!(clause.to_sql(out));
         }
-        out.pop_context();
         Ok(())
     }
 }
@@ -81,11 +79,9 @@ impl<T, U, DB> QueryFragment<DB> for UpdateQuery<T, U> where
     UpdateStatement<T, U>: QueryFragment<DB>,
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        out.push_context(Context::Update);
         try!(self.0.to_sql(out));
         out.push_sql(" RETURNING ");
         try!(T::Table::all_columns().to_sql(out));
-        out.pop_context();
         Ok(())
     }
 }

--- a/diesel_codegen/src/update.rs
+++ b/diesel_codegen/src/update.rs
@@ -8,7 +8,7 @@ use syntax::parse::token::{InternedString, str_to_ident};
 
 use attr::Attr;
 use model::Model;
-use util::ty_param_of_option;
+use util::{ty_param_of_option, is_option_ty};
 
 pub fn expand_changeset_for(
     cx: &mut ExtCtxt,
@@ -205,8 +205,4 @@ fn changeset_expr(
     } else {
         quote_expr!(cx, $column.eq(&self.$field_name))
     }
-}
-
-fn is_option_ty(ty: &ast::Ty) -> bool {
-    ty_param_of_option(ty).is_some()
 }

--- a/diesel_codegen/src/util.rs
+++ b/diesel_codegen/src/util.rs
@@ -77,3 +77,7 @@ pub fn ty_param_of_option(ty: &ast::Ty) -> Option<&P<ast::Ty>> {
         _ => None,
     }
 }
+
+pub fn is_option_ty(ty: &ast::Ty) -> bool {
+    ty_param_of_option(ty).is_some()
+}

--- a/diesel_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -36,20 +36,28 @@ impl<DB: Backend> Queryable<(Integer, VarChar), DB> for User where
 pub struct NewUser(String);
 
 use diesel::backend::Sqlite;
-use diesel::expression::AsExpression;
-use diesel::expression::grouped::Grouped;
-use diesel::expression::helper_types::AsExpr;
+use diesel::persistable::InsertValues;
+use diesel::query_builder::BuildQueryResult;
+use diesel::query_builder::sqlite::SqliteQueryBuilder;
 
-impl<'a> Insertable<users::table, Sqlite> for &'a NewUser {
-    type Columns = users::name;
-    type Values = Grouped<AsExpr<&'a String, users::name>>;
-
-    fn columns() -> Self::Columns {
-        users::name
+// It doesn't actually matter if this would work. We're testing that insert fails
+// to compile here.
+pub struct MyValues;
+impl InsertValues<Sqlite> for MyValues {
+    fn column_names(&self, out: &mut SqliteQueryBuilder) -> BuildQueryResult {
+        Ok(())
     }
 
+    fn values_clause(&self, out: &mut SqliteQueryBuilder) -> BuildQueryResult {
+        Ok(())
+    }
+}
+
+impl<'a> Insertable<users::table, Sqlite> for &'a NewUser {
+    type Values = MyValues;
+
     fn values(self) -> Self::Values {
-        Grouped(<&'a String as AsExpression<VarChar>>::as_expression(&self.0))
+        MyValues
     }
 }
 

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -87,7 +87,6 @@ fn insert_with_defaults() {
 }
 
 #[test]
-#[should_panic] // FIXME: SQLite has no DEFAULT keyword. We need to work around this.
 #[cfg(feature = "sqlite")] // FIXME: This test should run on everything, the only difference is create table syntax.
 fn insert_with_defaults() {
     use schema::users::table as users;


### PR DESCRIPTION
Our previous infrastructure relied on the ability to use the `DEFAULT`
keyword for values which were not present. This keyword does not exist
on SQLite. This means that the query:

```sql
INSERT INTO users (name, hair_color) VALUES ('Tess', DEFAULT)
```

needs to instead be written as

```sql
INSERT INTO users (name) VALUES ('Tess')
```

This does not work for batch inserts, where some of the rows provide
values, but others want the defaults. There is no way to express this in
a single query using SQLite. Because of this, we disallowed batch
inserts for SQLite entirely in 10caf03dd8566977bc63f18ebc784f6b61b99eb4.
This issue will be revisted after 0.5 is released.

There were several changes included in this commit which are
tangentially related to this change.

We were able to remove the "context" concept from our query builder
entirely. This was only there to insert the `"DEFAULT"` keyword instead
of a bind param on nulls during insert. It was never something I was
super happy with, and it resulted in allocations that the compiler would
never be able to optimize away. With this change, we have a better place
to handle this.

I've had to alter codegen to specifically reference `Bound` instead of
using the `AsExpr` helper which is technically corrent. Without that
change, we get some very obscure lifetime errors that I honestly don't
fully understand. This is either a bug in Rust itself, or some *very*
obscure interaction with
https://github.com/sgrif/diesel/blob/8a33029/diesel/src/types/impls/mod.rs#L23-L29
that I do not understand (I believe it is a bug in Rust, given that it
only manifests in `where` clauses. I have been unable to isolate it in a
playground link, but I will follow up with the core team tomorrow on
this.)

The changes that were required to the `migrations` module are
unfortunate, but necessary. Even though SQLite is the *only* backend
which would not implement `SupportsDefaultKeyword`, I have no way to
represent this in the type system. As such, I can provide no evidence
that a tuple of `ColumnInsertValue`s always implements
`InsertValues<DB>` for all possible `DB`. This can go away once
specialization lands in stable.

Ultimately we can likely re-implement batch inserts for SQLite in the
future by having it execute one query per row under the hood. As has
been pointed out to me numerous times in other places, since SQLite is
an embedded databbase, there is no downside to doing 10 queries instead
of 1 (assuming we're in a transaction so there is no IO cost).

Fixes #157