### PR TITLE
Fix failing build due to old sqlite3 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-dist: trusty
+dist: precise
 rust:
   - stable
   - beta
@@ -7,6 +7,11 @@ rust:
   - nightly
 addons:
   postgresql: '9.4'
+before_install:
+  - sudo apt-get autoremove -y sqlite3
+  - sudo apt-add-repository -y ppa:travis-ci/sqlite3
+  - sudo apt-get -y update
+  - sudo apt-get install -y sqlite3=3.7.15.1-1~travis1
 before_script:
   - pip install 'travis-cargo<0.2' --user
   - export PATH=$HOME/.local/bin:$PATH


### PR DESCRIPTION
It seems that the original post in #167 was correct, the sqlite support branch was failing due to an ancient version of sqlite.

Tavis CI has provided a workaround for this, but it seems to only work on Ubuntu Precise. I haven't been able to tell for sure if this slows down the build, but it doesn't seem like it at the moment. One foreseeable issue is that this prevents moving to Travis' new container infrastructure, which offers features like caching.

Any thoughts on possible alternatives?