### PR TITLE
Allow backend agnostic table creation in tests

### DIFF
--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -66,68 +66,21 @@ fn batch_insert_with_defaults() {
 }
 
 #[test]
-#[cfg(feature = "postgres")] // FIXME: This test should run on everything, the only difference is create table syntax.
 fn insert_with_defaults() {
     use schema::users::table as users;
+    use schema_dsl::*;
+
     let connection = connection();
     connection.execute("DROP TABLE users").unwrap();
-    connection.execute("CREATE TABLE users (
-        id SERIAL PRIMARY KEY,
-        name VARCHAR NOT NULL,
-        hair_color VARCHAR NOT NULL DEFAULT 'Green'
-    )").unwrap();
+    create_table("users", (
+        integer("id").primary_key().auto_increment(),
+        string("name").not_null(),
+        string("hair_color").not_null().default("'Green'"),
+    )).execute(&connection).unwrap();
     insert(&NewUser::new("Tess", None)).into(users).execute(&connection).unwrap();
 
     let expected_users = vec![
         User { id: 1, name: "Tess".to_string(), hair_color: Some("Green".to_string()) },
-    ];
-    let actual_users: Vec<_> = users.load(&connection).unwrap().collect();
-
-    assert_eq!(expected_users, actual_users);
-}
-
-#[test]
-#[cfg(feature = "sqlite")] // FIXME: This test should run on everything, the only difference is create table syntax.
-fn insert_with_defaults() {
-    use schema::users::table as users;
-    use diesel::expression::dsl::sql;
-    let connection = connection();
-    connection.execute("DROP TABLE users").unwrap();
-    connection.execute("CREATE TABLE users (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        name VARCHAR NOT NULL,
-        hair_color VARCHAR NOT NULL DEFAULT 'Green'
-    )").unwrap();
-    insert(&NewUser::new("Tess", None)).into(users).execute(&connection).unwrap();
-
-    let expected_users = vec![
-        User { id: 1, name: "Tess".to_string(), hair_color: Some("Green".to_string()) },
-    ];
-    let actual_users: Vec<_> = users.load(&connection).unwrap().collect();
-
-    assert_eq!(expected_users, actual_users);
-}
-
-#[test]
-#[cfg(feature = "postgres")] // FIXME: This test should run on everything, the only difference is create table syntax.
-fn insert_with_defaults_not_provided() {
-    use schema::users::table as users;
-    let connection = connection();
-    connection.execute("DROP TABLE users").unwrap();
-    connection.execute("CREATE TABLE users (
-        id SERIAL PRIMARY KEY,
-        name VARCHAR NOT NULL,
-        hair_color VARCHAR NOT NULL DEFAULT 'Green'
-    )").unwrap();
-    let new_users: &[_] = &[
-        BaldUser { name: "Sean".to_string() },
-        BaldUser { name: "Tess".to_string() },
-    ];
-    insert(new_users).into(users).execute(&connection).unwrap();
-
-    let expected_users = vec![
-        User { id: 1, name: "Sean".to_string(), hair_color: Some("Green".to_string()) },
-        User { id: 2, name: "Tess".to_string(), hair_color: Some("Green".to_string()) },
     ];
     let actual_users: Vec<_> = users.load(&connection).unwrap().collect();
 

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -23,6 +23,7 @@ mod joins;
 mod macros;
 mod order;
 mod perf_details;
+mod schema_dsl;
 mod select;
 #[cfg(feature = "postgres")] // FIXME: There are valuable tests for SQLite here
 mod transactions;

--- a/diesel_tests/tests/schema_dsl/functions.rs
+++ b/diesel_tests/tests/schema_dsl/functions.rs
@@ -1,0 +1,17 @@
+use diesel::types;
+
+use super::structures::*;
+
+pub fn create_table<'a, Cols>(name: &'a str, columns: Cols)
+    -> CreateTable<'a, Cols>
+{
+    CreateTable::new(name, columns)
+}
+
+pub fn integer<'a>(name: &'a str) -> Column<'a, types::Integer> {
+    Column::new(name, "INTEGER", types::Integer)
+}
+
+pub fn string<'a>(name: &'a str) -> Column<'a, types::VarChar> {
+    Column::new(name, "VARCHAR", types::VarChar)
+}

--- a/diesel_tests/tests/schema_dsl/mod.rs
+++ b/diesel_tests/tests/schema_dsl/mod.rs
@@ -1,0 +1,4 @@
+mod structures;
+mod functions;
+
+pub use self::functions::*;

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -1,0 +1,144 @@
+pub struct CreateTable<'a, Cols> {
+    name: &'a str,
+    columns: Cols
+}
+
+impl<'a, Cols> CreateTable<'a, Cols> {
+    pub fn new(name: &'a str, columns: Cols) -> Self {
+        CreateTable {
+            name: name,
+            columns: columns,
+        }
+    }
+}
+
+pub struct Column<'a, T> {
+    name: &'a str,
+    type_name: &'a str,
+    _tpe: T,
+}
+
+impl<'a, T> Column<'a, T> {
+    pub fn new(name: &'a str, type_name: &'a str, tpe: T) -> Self {
+        Column {
+            name: name,
+            type_name: type_name,
+            _tpe: tpe,
+        }
+    }
+
+    pub fn primary_key(self) -> PrimaryKey<Self> {
+        PrimaryKey(self)
+    }
+
+    pub fn not_null(self) -> NotNull<Self> {
+        NotNull(self)
+    }
+}
+
+pub struct PrimaryKey<Col>(Col);
+
+impl<Col> PrimaryKey<Col> {
+    pub fn auto_increment(self) -> AutoIncrement<Self> {
+        AutoIncrement(self)
+    }
+}
+
+pub struct AutoIncrement<Col>(Col);
+
+pub struct NotNull<Col>(Col);
+
+impl<'a, T> NotNull<Column<'a, T>> {
+    pub fn default<'b>(self, expr: &'b str) -> Default<'b, Self> {
+        Default {
+            column: self,
+            value: expr,
+        }
+    }
+}
+
+pub struct Default<'a, Col> {
+    column: Col,
+    value: &'a str,
+}
+
+use diesel::backend::*;
+use diesel::query_builder::*;
+use diesel::types::Integer;
+
+impl<'a, DB, Cols> QueryFragment<DB> for CreateTable<'a, Cols> where
+    DB: Backend,
+    Cols: QueryFragment<DB>,
+{
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        out.push_sql("CREATE TABLE ");
+        try!(out.push_identifier(self.name));
+        out.push_sql(" (");
+        try!(self.columns.to_sql(out));
+        out.push_sql(")");
+        Ok(())
+    }
+}
+
+impl<'a, DB, T> QueryFragment<DB> for Column<'a, T> where
+    DB: Backend,
+{
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        try!(out.push_identifier(self.name));
+        out.push_sql(" ");
+        out.push_sql(self.type_name);
+        Ok(())
+    }
+}
+
+impl<DB, Col> QueryFragment<DB> for PrimaryKey<Col> where
+    DB: Backend,
+    Col: QueryFragment<DB>,
+{
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        try!(self.0.to_sql(out));
+        out.push_sql(" PRIMARY KEY");
+        Ok(())
+    }
+}
+
+impl<Col> QueryFragment<Sqlite> for AutoIncrement<Col> where
+    Col: QueryFragment<Sqlite>,
+{
+    fn to_sql(&self, out: &mut <Sqlite as Backend>::QueryBuilder) -> BuildQueryResult {
+        try!(self.0.to_sql(out));
+        out.push_sql(" AUTOINCREMENT");
+        Ok(())
+    }
+}
+
+impl<'a> QueryFragment<Pg> for AutoIncrement<PrimaryKey<Column<'a, Integer>>> {
+    fn to_sql(&self, out: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
+        try!(out.push_identifier((self.0).0.name));
+        out.push_sql(" SERIAL PRIMARY KEY");
+        Ok(())
+    }
+}
+
+impl<DB, Col> QueryFragment<DB> for NotNull<Col> where
+    DB: Backend,
+    Col: QueryFragment<DB>,
+{
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        try!(self.0.to_sql(out));
+        out.push_sql(" NOT NULL");
+        Ok(())
+    }
+}
+
+impl<'a, DB, Col> QueryFragment<DB> for Default<'a, Col> where
+    DB: Backend,
+    Col: QueryFragment<DB>,
+{
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        try!(self.column.to_sql(out));
+        out.push_sql(" DEFAULT ");
+        out.push_sql(self.value);
+        Ok(())
+    }
+}

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -1,5 +1,6 @@
 use super::schema::*;
 use diesel::*;
+use schema_dsl::*;
 
 #[test]
 fn selecting_basic_data() {
@@ -108,15 +109,14 @@ table! {
 }
 
 #[test]
-#[cfg(feature = "postgres")] // FIXME: This test should run on everything, the only difference is create table syntax.
 fn selecting_columns_and_tables_with_reserved_names() {
     use self::select::dsl::*;
 
     let connection = connection();
-    connection.execute("CREATE TABLE \"select\" (
-        id SERIAL PRIMARY KEY,
-        \"join\" INTEGER NOT NULL
-    )").unwrap();
+    create_table("select", (
+        integer("id").primary_key().auto_increment(),
+        integer("join").not_null(),
+    )).execute(&connection).unwrap();
     connection.execute("INSERT INTO \"select\" (\"join\") VALUES (1), (2), (3)")
         .unwrap();
 
@@ -132,51 +132,14 @@ fn selecting_columns_and_tables_with_reserved_names() {
 }
 
 #[test]
-#[cfg(feature = "sqlite")] // FIXME: This test should run on everything, the only difference is create table syntax.
-fn selecting_columns_and_tables_with_reserved_names() {
-    use self::select::dsl::*;
-
-    let connection = connection();
-    connection.execute("CREATE TABLE \"select\" (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        \"join\" INTEGER NOT NULL
-    )").unwrap();
-    connection.execute("INSERT INTO \"select\" (\"join\") VALUES (1), (2), (3)")
-        .unwrap();
-
-    let expected_data = vec![(1, 1), (2, 2), (3, 3)];
-    let actual_data: Vec<(i32, i32)> = select.load(&connection)
-        .unwrap().collect();
-    assert_eq!(expected_data, actual_data);
-
-    let expected_data = vec![1, 2, 3];
-    let actual_data: Vec<i32> = select.select(join).load(&connection)
-        .unwrap().collect();
-    assert_eq!(expected_data, actual_data);
-}
-
-#[test]
-#[cfg(feature = "postgres")] // FIXME: This test should run on everything, the only difference is create table syntax.
 fn selecting_columns_with_different_definition_order() {
     let connection = connection();
     connection.execute("DROP TABLE users").unwrap();
-    connection.execute("CREATE TABLE users (id SERIAL PRIMARY KEY, hair_color VARCHAR, name VARCHAR NOT NULL)")
-        .unwrap();
-    let expected_user = User::with_hair_color(1, "Sean", "black");
-    insert(&NewUser::new("Sean", Some("black"))).into(users::table)
-        .execute(&connection).unwrap();
-    let user_from_select = users::table.first(&connection);
-
-    assert_eq!(Ok(&expected_user), user_from_select.as_ref());
-}
-
-#[test]
-#[cfg(feature = "sqlite")] // FIXME: This test should run on everything, the only difference is create table syntax.
-fn selecting_columns_with_different_definition_order() {
-    let connection = connection();
-    connection.execute("DROP TABLE users").unwrap();
-    connection.execute("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, hair_color VARCHAR, name VARCHAR NOT NULL)")
-        .unwrap();
+    create_table("users", (
+        integer("id").primary_key().auto_increment(),
+        string("hair_color"),
+        string("name").not_null(),
+    )).execute(&connection).unwrap();
     let expected_user = User::with_hair_color(1, "Sean", "black");
     insert(&NewUser::new("Sean", Some("black"))).into(users::table)
         .execute(&connection).unwrap();


### PR DESCRIPTION
I have not added this DSL to the public API, as it's unsuitable for
public use at this time. It handles nothing other than the exact cases
that we need in our test suite, and requires you to manually quote
default values.

Fixes #158