### PR TITLE
Run significantly more of our test suite against SQLite

### DIFF
--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "postgres")] // FIXME: We need to test this on SQLite when we support these types
 mod date_and_time;
 mod ops;
 
@@ -11,7 +12,7 @@ use diesel::expression::dsl::*;
 #[test]
 fn test_count_counts_the_rows() {
     let connection = connection();
-    let source = users.select(count(users.star()));
+    let source = users.select(count(id));
 
     assert_eq!(Ok(0), source.first(&connection));
     insert(&NewUser::new("Sean", None)).into(users).execute(&connection).unwrap();
@@ -153,10 +154,8 @@ fn function_with_multiple_arguments() {
     use schema::users::dsl::*;
 
     let connection = connection();
-    insert(&vec![NewUser::new("Sean", Some("black")), NewUser::new("Tess", None)])
-        .into(users)
-        .execute(&connection)
-        .unwrap();
+    let new_users = vec![NewUser::new("Sean", Some("black")), NewUser::new("Tess", None)];
+    batch_insert(&new_users, users, &connection);
 
     let expected_data = vec!["black".to_string(), "Tess".to_string()];
     let data: QueryResult<Vec<String>> = users.select(coalesce(hair_color, name))
@@ -255,6 +254,7 @@ fn test_avg_for_nullable() {
 }
 
 #[test]
+#[cfg(feature = "postgres")] // FIXME: We need to test this on SQLite when we support these types
 fn test_avg_for_integer() {
     use self::numbers::columns::*;
     use self::numbers::table as numbers;
@@ -289,6 +289,7 @@ table! {
 }
 
 #[test]
+#[cfg(feature = "postgres")] // FIXME: We need to test this on SQLite
 fn test_avg_for_numeric() {
     use self::numeric::columns::*;
     use self::numeric::table as numeric;

--- a/diesel_tests/tests/lib.in.rs
+++ b/diesel_tests/tests/lib.in.rs
@@ -1,7 +1,6 @@
-#[cfg(feature = "postgres")] // FIXME: There are valuable tests for SQLite here
+#[cfg(not(feature = "sqlite"))]
 mod annotations;
 mod deserialization;
 mod insert;
 mod schema;
-#[cfg(feature = "postgres")] // FIXME: There are valuable tests for SQLite here
 mod update;

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -12,22 +12,18 @@ include!(concat!(env!("OUT_DIR"), "/lib.rs"));
 
 #[cfg(feature = "postgres")] // FIXME: There are valuable tests for SQLite here
 mod associations;
-#[cfg(feature = "postgres")] // FIXME: There are valuable tests for SQLite here
 mod expressions;
 mod filter;
 mod filter_operators;
 mod find;
 mod internal_details;
-#[cfg(feature = "postgres")] // FIXME: There are valuable tests for SQLite here
 mod joins;
 mod macros;
 mod order;
 mod perf_details;
 mod schema_dsl;
 mod select;
-#[cfg(feature = "postgres")] // FIXME: There are valuable tests for SQLite here
 mod transactions;
-#[cfg(feature = "postgres")] // FIXME: There are valuable tests for SQLite here
 mod types;
 mod types_roundtrip;
 mod debug;

--- a/diesel_tests/tests/postgres_specific_schema.rs
+++ b/diesel_tests/tests/postgres_specific_schema.rs
@@ -1,0 +1,27 @@
+use diesel::*;
+use super::User;
+
+infer_schema!(dotenv!("DATABASE_URL"));
+
+#[derive(PartialEq, Eq, Debug, Clone, Queryable)]
+#[has_many(comments)]
+#[belongs_to(user)]
+pub struct Post {
+    pub id: i32,
+    pub user_id: i32,
+    pub title: String,
+    pub body: Option<String>,
+    pub tags: Vec<String>,
+}
+
+impl Post {
+    pub fn new(id: i32, user_id: i32, title: &str, body: Option<&str>) -> Self {
+        Post {
+            id: id,
+            user_id: user_id,
+            title: title.to_string(),
+            body: body.map(|s| s.to_string()),
+            tags: Vec::new(),
+        }
+    }
+}

--- a/diesel_tests/tests/sqlite_specific_schema.rs
+++ b/diesel_tests/tests/sqlite_specific_schema.rs
@@ -1,0 +1,64 @@
+use diesel::*;
+use super::User;
+
+//FIXME: We can go back to `infer_schema!` when codegen becomes generic
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+        hair_color -> Nullable<VarChar>,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        user_id -> Integer,
+        title -> VarChar,
+        body -> Nullable<Text>,
+    }
+}
+
+table! {
+    comments {
+        id -> Integer,
+        post_id -> Integer,
+        text -> Text,
+    }
+}
+
+table! {
+    special_posts {
+        id -> Integer,
+        user_id -> Integer,
+        title -> VarChar,
+    }
+}
+
+table! {
+    special_comments {
+        id -> Integer,
+        special_post_id -> Integer,
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, Clone, Queryable)]
+#[has_many(comments)]
+#[belongs_to(user)]
+pub struct Post {
+    pub id: i32,
+    pub user_id: i32,
+    pub title: String,
+    pub body: Option<String>,
+}
+
+impl Post {
+    pub fn new(id: i32, user_id: i32, title: &str, body: Option<&str>) -> Self {
+        Post {
+            id: id,
+            user_id: user_id,
+            title: title.to_string(),
+            body: body.map(|s| s.to_string()),
+        }
+    }
+}

--- a/diesel_tests/tests/transactions.rs
+++ b/diesel_tests/tests/transactions.rs
@@ -11,6 +11,7 @@ macro_rules! try_no_coerce {
 }
 
 #[test]
+#[cfg(not(feature = "sqlite"))] // FIXME: This test is only valid when operating on a file and not :memory:
 fn transaction_executes_fn_in_a_sql_transaction() {
     let conn1 = connection_without_transaction();
     let conn2 = connection_without_transaction();
@@ -112,7 +113,10 @@ fn test_transaction_panics_on_error() {
 }
 
 fn setup_test_table(connection: &TestConnection, table_name: &str) {
-    connection.execute(&format!("CREATE TABLE {} (id SERIAL PRIMARY KEY)", table_name)).unwrap();
+    use schema_dsl::*;
+    create_table(table_name, (
+        integer("id").primary_key().auto_increment(),
+    )).execute(connection).unwrap();
 }
 
 fn drop_test_table(connection: &TestConnection, table_name: &str) {

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1,15 +1,19 @@
-use schema::connection;
+// FIXME: Review this module to see if we can do these casts in a more backend agnostic way
+
+use schema::{connection, TestBackend};
 use diesel::*;
 use diesel::backend::Pg;
 use diesel::types::*;
 
 #[test]
+#[cfg(feature = "postgres")]
 fn boolean_from_sql() {
     assert_eq!(true, query_single_value::<Bool, bool>("'t'::bool"));
     assert_eq!(false, query_single_value::<Bool, bool>("'f'::bool"));
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn boolean_treats_null_as_false_when_predicates_return_null() {
     let connection = connection();
     let one = AsExpression::<Nullable<Integer>>::as_expression(Some(1));
@@ -18,6 +22,7 @@ fn boolean_treats_null_as_false_when_predicates_return_null() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn boolean_to_sql() {
     assert!(query_to_sql_equality::<Bool, bool>("'t'::bool", true));
     assert!(query_to_sql_equality::<Bool, bool>("'f'::bool", false));
@@ -26,6 +31,7 @@ fn boolean_to_sql() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn i16_from_sql() {
     assert_eq!(0, query_single_value::<SmallInt, i16>("0::int2"));
     assert_eq!(-1, query_single_value::<SmallInt, i16>("-1::int2"));
@@ -33,6 +39,7 @@ fn i16_from_sql() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn i16_to_sql_smallint() {
     assert!(query_to_sql_equality::<SmallInt, i16>("0::int2", 0));
     assert!(query_to_sql_equality::<SmallInt, i16>("-1::int2", -1));
@@ -58,6 +65,7 @@ fn i32_to_sql_integer() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn i64_from_sql() {
     assert_eq!(0, query_single_value::<BigInt, i64>("0::int8"));
     assert_eq!(-1, query_single_value::<BigInt, i64>("-1::int8"));
@@ -66,6 +74,7 @@ fn i64_from_sql() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn i64_to_sql_bigint() {
     assert!(query_to_sql_equality::<BigInt, i64>("0::int8", 0));
     assert!(query_to_sql_equality::<BigInt, i64>("-1::int8", -1));
@@ -77,6 +86,7 @@ fn i64_to_sql_bigint() {
 use std::{f32, f64};
 
 #[test]
+#[cfg(feature = "postgres")]
 fn f32_from_sql() {
     assert_eq!(0.0, query_single_value::<Float, f32>("0.0::real"));
     assert_eq!(0.5, query_single_value::<Float, f32>("0.5::real"));
@@ -89,6 +99,7 @@ fn f32_from_sql() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn f32_to_sql_float() {
     assert!(query_to_sql_equality::<Float, f32>("0.0::real", 0.0));
     assert!(query_to_sql_equality::<Float, f32>("0.5::real", 0.5));
@@ -102,6 +113,7 @@ fn f32_to_sql_float() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn f64_from_sql() {
     assert_eq!(0.0, query_single_value::<Double, f64>("0.0::double precision"));
     assert_eq!(0.5, query_single_value::<Double, f64>("0.5::double precision"));
@@ -114,6 +126,7 @@ fn f64_from_sql() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn f64_to_sql_float() {
     assert!(query_to_sql_equality::<Double, f64>("0.0::double precision", 0.0));
     assert!(query_to_sql_equality::<Double, f64>("0.5::double precision", 0.5));
@@ -150,6 +163,7 @@ fn string_to_sql_varchar() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn binary_from_sql() {
     let invalid_utf8_bytes = vec![0x1Fu8, 0x8Bu8];
     assert_eq!(invalid_utf8_bytes,
@@ -161,6 +175,7 @@ fn binary_from_sql() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn bytes_to_sql_binary() {
     let invalid_utf8_bytes = vec![0x1Fu8, 0x8Bu8];
     assert!(query_to_sql_equality::<Binary, Vec<u8>>("E'\\\\x1F8B'::bytea",
@@ -174,9 +189,14 @@ fn bytes_to_sql_binary() {
 }
 
 #[test]
-fn option_from_sql() {
+#[cfg(feature = "postgres")]
+fn pg_specific_option_from_sql() {
     assert_eq!(Some(true),
     query_single_value::<Nullable<Bool>, Option<bool>>("'t'::bool"));
+}
+
+#[test]
+fn option_from_sql() {
     assert_eq!(None,
                query_single_value::<Nullable<Bool>, Option<bool>>("NULL"));
     assert_eq!(Some(1),
@@ -192,11 +212,16 @@ fn option_from_sql() {
 }
 
 #[test]
-fn option_to_sql() {
+#[cfg(feature = "postgres")]
+fn pg_specific_option_to_sql() {
     assert!(query_to_sql_equality::<Nullable<Bool>, Option<bool>>("'t'::bool", Some(true)));
     assert!(!query_to_sql_equality::<Nullable<Bool>, Option<bool>>("'f'::bool", Some(true)));
     assert!(query_to_sql_equality::<Nullable<Bool>, Option<bool>>("NULL", None));
     assert!(!query_to_sql_equality::<Nullable<Bool>, Option<bool>>("NULL::bool", Some(false)));
+}
+
+#[test]
+fn option_to_sql() {
     assert!(query_to_sql_equality::<Nullable<Integer>, Option<i32>>("1", Some(1)));
     assert!(query_to_sql_equality::<Nullable<Integer>, Option<i32>>("NULL", None));
     assert!(query_to_sql_equality::<Nullable<VarChar>,
@@ -207,6 +232,7 @@ fn option_to_sql() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn pg_array_from_sql() {
     assert_eq!(vec![true, false, true],
                query_single_value::<Array<Bool>, Vec<bool>>(
@@ -219,6 +245,7 @@ fn pg_array_from_sql() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn to_sql_array() {
     assert!(query_to_sql_equality::<Array<Bool>, Vec<bool>>(
             "ARRAY['t', 'f', 't']::bool[]", vec![true, false, true]));
@@ -233,6 +260,7 @@ fn to_sql_array() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn pg_array_containing_null() {
     let query = "ARRAY['Hello', '', NULL, 'world']";
     let data = query_single_value::<Array<Nullable<VarChar>>, Vec<Option<String>>>(query);
@@ -246,6 +274,7 @@ fn pg_array_containing_null() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn timestamp_from_sql() {
     use diesel::data_types::PgTimestamp;
 
@@ -258,6 +287,7 @@ fn timestamp_from_sql() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn pg_timestamp_to_sql_timestamp() {
     use diesel::data_types::PgTimestamp;
 
@@ -272,6 +302,7 @@ fn pg_timestamp_to_sql_timestamp() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn pg_numeric_from_sql() {
     use diesel::data_types::PgNumeric;
 
@@ -295,6 +326,7 @@ fn pg_numeric_from_sql() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn third_party_crates_can_add_new_types() {
     use std::error::Error;
     use std::io::prelude::*;
@@ -332,8 +364,8 @@ fn third_party_crates_can_add_new_types() {
     assert_eq!(70000, query_single_value::<MyInt, i32>("70000"));
 }
 
-fn query_single_value<T, U: Queryable<T, Pg>>(sql_str: &str) -> U where
-    Pg: HasSqlType<T>,
+fn query_single_value<T, U: Queryable<T, TestBackend>>(sql_str: &str) -> U where
+    TestBackend: HasSqlType<T>,
 {
     use diesel::expression::dsl::sql;
     let connection = connection();
@@ -345,12 +377,15 @@ use diesel::expression::AsExpression;
 use diesel::query_builder::QueryFragment;
 
 fn query_to_sql_equality<T, U>(sql_str: &str, value: U) -> bool where
-    Pg: HasSqlType<T>,
+    TestBackend: HasSqlType<T>,
     U: AsExpression<T> + Debug + Clone,
-    U::Expression: SelectableExpression<(), T> + QueryFragment<Pg>,
+    U::Expression: SelectableExpression<(), T> + QueryFragment<TestBackend>,
 {
     use diesel::expression::dsl::sql;
     let connection = connection();
-    let query = select(sql::<T>(sql_str).is_not_distinct_from(value.clone()));
+    let query = select(
+        sql::<T>(sql_str).is_null().and(value.clone().as_expression().is_null()).or(
+            sql::<T>(sql_str).eq(value.clone()))
+    );
     query.get_result(&connection).expect(&format!("Error comparing {}, {:?}", sql_str, value))
 }

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -71,6 +71,7 @@ fn test_updating_multiple_columns() {
 }
 
 #[test]
+#[cfg(not(feature="sqlite"))]
 fn update_returning_struct() {
     use schema::users::dsl::*;
 
@@ -84,6 +85,7 @@ fn update_returning_struct() {
 }
 
 #[test]
+#[cfg(not(feature="sqlite"))] // FIXME: This test is probably still valid without using RETURNING
 fn update_with_struct_as_changes() {
     use schema::users::dsl::*;
 
@@ -99,6 +101,7 @@ fn update_with_struct_as_changes() {
 }
 
 #[test]
+#[cfg(not(feature="sqlite"))] // FIXME: This test is probably still valid without using RETURNING
 fn update_with_struct_does_not_set_primary_key() {
     use schema::users::dsl::*;
 
@@ -115,6 +118,7 @@ fn update_with_struct_does_not_set_primary_key() {
 }
 
 #[test]
+#[cfg(not(feature="sqlite"))] // FIXME: `save_changes` is still useful on SQLite, we need to support it
 fn save_on_struct_with_primary_key_changes_that_struct() {
     use schema::users::dsl::*;
 
@@ -128,6 +132,7 @@ fn save_on_struct_with_primary_key_changes_that_struct() {
 }
 
 #[test]
+#[cfg(not(feature="sqlite"))] // FIXME: `save_changes` is still useful on SQLite, we need to support it
 fn option_fields_on_structs_are_not_assigned() {
     use schema::users::dsl::*;
 
@@ -143,6 +148,7 @@ fn option_fields_on_structs_are_not_assigned() {
 }
 
 #[test]
+#[cfg(not(feature="sqlite"))] // FIXME: This test is probably still valid without using RETURNING
 fn sql_syntax_is_correct_when_option_field_comes_before_non_option() {
     #[changeset_for(users)]
     struct Changes {
@@ -161,6 +167,7 @@ fn sql_syntax_is_correct_when_option_field_comes_before_non_option() {
 }
 
 #[test]
+#[cfg(not(feature="sqlite"))] // FIXME: This test is probably still valid without using RETURNING
 fn sql_syntax_is_correct_when_option_field_comes_mixed_with_non_option() {
     #[changeset_for(posts)]
     struct Changes {
@@ -185,6 +192,7 @@ fn sql_syntax_is_correct_when_option_field_comes_mixed_with_non_option() {
 }
 
 #[test]
+#[cfg(not(feature="sqlite"))] // FIXME: This test is probably still valid without using RETURNING
 fn can_update_with_struct_containing_single_field() {
     #[changeset_for(posts)]
     struct SetBody {
@@ -207,6 +215,7 @@ fn can_update_with_struct_containing_single_field() {
 }
 
 #[test]
+#[cfg(not(feature="sqlite"))] // FIXME: This test is probably still valid without using RETURNING
 fn struct_with_option_fields_treated_as_null() {
     #[changeset_for(posts, treat_none_as_null="true", __skip_visibility="true")]
     struct UpdatePost {


### PR DESCRIPTION
This removes the usage of the `infer_schema!` macro, which was
previously compiling against PG. We may eventually be able to use it
again on SQLite, but I think making that macro backend agnostic is out
of scope for 0.5. The `Post` struct on SQLite also does not contain the
`tags` field, which would make no sense on SQLite.

I've opted to leave the `annotations` module out of SQLite, as it'll be
a pain to stop using batch insert and returning there, and really it's
only testing that codegen generates valid Rust in various edge cases,
which isn't something that would change for SQLite.

Fixes #155 (more or less)