### PR TITLE
Clean up the migration signatures to something reasonable

### DIFF
--- a/diesel/src/migrations/connection.rs
+++ b/diesel/src/migrations/connection.rs
@@ -1,0 +1,41 @@
+use std::collections::HashSet;
+
+use prelude::*;
+use super::schema::NewMigration;
+use super::schema::__diesel_schema_migrations::dsl::*;
+use types::{FromSql, VarChar};
+
+/// A connection which can be passed to the migration methods. This exists only
+/// to wrap up some constraints which are meant to hold for *all* connections.
+/// This trait will go away at some point in the future. Any Diesel connection
+/// should be useable where this trait is required.
+pub trait MigrationConnection: Connection {
+    fn previously_run_migration_versions(&self) -> QueryResult<HashSet<String>>;
+    fn latest_run_migration_version(&self) -> QueryResult<String>;
+    fn insert_new_migration(&self, version: &str) -> QueryResult<()>;
+}
+
+impl<T> MigrationConnection for T where
+    T: Connection,
+    String: FromSql<VarChar, T::Backend>,
+    for<'a> &'a NewMigration<'a>: Insertable<__diesel_schema_migrations, T::Backend>,
+{
+    fn previously_run_migration_versions(&self) -> QueryResult<HashSet<String>> {
+        __diesel_schema_migrations.select(version)
+            .load(self)
+            .map(|r| r.collect())
+    }
+
+    fn latest_run_migration_version(&self) -> QueryResult<String> {
+        use ::expression::dsl::max;
+        __diesel_schema_migrations.select(max(version))
+            .first(self)
+    }
+
+    fn insert_new_migration(&self, ver: &str) -> QueryResult<()> {
+        try!(::insert(&NewMigration(ver))
+             .into(__diesel_schema_migrations)
+             .execute(self));
+        Ok(())
+    }
+}


### PR DESCRIPTION
The where clauses that were needed when we moved to a generic backend
structure are leaking into the docs, making these functions seem way
more scary than they actually are (this could just as easily be
`&Connection` if connection were object safe).

<img width="976" alt="screen shot 2016-02-04 at 10 30 01 am" src="https://cloud.githubusercontent.com/assets/1529387/12823617/443accf0-cb2a-11e5-9187-b93bf12aa8d1.png">

I've moved everything onto another trait so that the signatures of these
functions look a bit more reasonable.

Review? @mcasper @mfpiccolo 