### PR TITLE
Panic if we failed to drop SQLite resources

### DIFF
--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -61,10 +61,16 @@ impl RawConnection {
 
 impl Drop for RawConnection {
     fn drop(&mut self) {
+        use std::thread::panicking;
+
         let close_result = unsafe { ffi::sqlite3_close(self.internal_connection) };
         if close_result != ffi::SQLITE_OK {
             let error_message = super::error_message(close_result);
-            write!(stderr(), "Error closing SQLite connection: {}", error_message).unwrap();
+            if panicking() {
+                write!(stderr(), "Error closing SQLite connection: {}", error_message).unwrap();
+            } else {
+                panic!("Error closing SQLite connection: {}", error_message);
+            }
         }
     }
 }

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -133,9 +133,15 @@ fn ensure_sqlite_ok(code: libc::c_int) -> QueryResult<()> {
 
 impl Drop for Statement {
     fn drop(&mut self) {
+        use std::thread::panicking;
+
         let finalize_result = unsafe { ffi::sqlite3_finalize(self.inner_statement) };
         if let Err(e) = ensure_sqlite_ok(finalize_result) {
-            write!(stderr(), "Error finalizing SQLite prepared statement: {:?}", e).unwrap();
+            if panicking() {
+                write!(stderr(), "Error finalizing SQLite prepared statement: {:?}", e).unwrap();
+            } else {
+                panic!("Error finalizing SQLite prepared statement: {:?}", e);
+            }
         }
     }
 }


### PR DESCRIPTION
SQLite is unique in that we can actually fail to clean up our resources
in `Drop`. The original implementation would *always* panic if we failed
there. However, the only time these `drop` calls would fail is if we're
in an inconsistent state. The most likely reason is that we are dropping
as the result of another `panic!`, which means that panicking will cause
Rust to abort with the unhelpful message "panicked while panicking".

However, I've had cases where the tests for SQLite have error output,
but did not fail, because this *isn't* panicking. This change causes us
to panic if not already panicking, and write to STDOUT otherwise. (Same
as before, we just crash if writing to stdout fails. If we can't clean
up resources, *and* we can't write to STDOUT, the computer is on fire.)