### PR TITLE
Add support for `IN` statements.

### DIFF
--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -1,0 +1,57 @@
+use backend::Backend;
+use expression::*;
+use query_builder::{QueryBuilder, QueryFragment, BuildQueryResult};
+use types::Bool;
+
+pub struct In<T, U> {
+    left: T,
+    values: Vec<U>,
+}
+
+impl<T, U> In<T, U> {
+    pub fn new(left: T, values: Vec<U>) -> Self {
+        In {
+            left: left,
+            values: values,
+        }
+    }
+}
+
+impl<T, U> Expression for In<T, U> where
+    T: Expression,
+    U: Expression<SqlType=T::SqlType>,
+{
+    type SqlType = Bool;
+}
+
+impl<T, U, QS> SelectableExpression<QS> for In<T, U> where
+    In<T, U>: Expression,
+    T: SelectableExpression<QS>,
+    U: SelectableExpression<QS>,
+{
+}
+
+impl<T, U> NonAggregate for In<T, U> where
+    In<T, U>: Expression,
+    T: NonAggregate,
+    U: NonAggregate,
+{
+}
+
+impl<T, U, DB> QueryFragment<DB> for In<T, U> where
+    DB: Backend,
+    T: QueryFragment<DB>,
+    U: QueryFragment<DB>,
+{
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        try!(self.left.to_sql(out));
+        out.push_sql(" IN (");
+        try!(self.values[0].to_sql(out));
+        for value in self.values[1..].iter() {
+            out.push_sql(", ");
+            try!(value.to_sql(out));
+        }
+        out.push_sql(")");
+        Ok(())
+    }
+}

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -20,6 +20,8 @@ pub mod ops;
 #[doc(hidden)]
 pub mod aliased;
 #[doc(hidden)]
+pub mod array_comparison;
+#[doc(hidden)]
 pub mod bound;
 #[doc(hidden)]
 pub mod count;

--- a/diesel_tests/tests/filter_operators.rs
+++ b/diesel_tests/tests/filter_operators.rs
@@ -122,6 +122,23 @@ fn filter_by_any() {
         users.filter(name.eq(any(borrowed_names))).load(&connection).unwrap());
 }
 
+#[test]
+fn filter_by_in() {
+    use schema::users::dsl::*;
+
+    let connection = connection_with_3_users();
+    let sean = User::new(1, "Sean");
+    let tess = User::new(2, "Tess");
+    let jim = User::new(3, "Jim");
+
+    let owned_names = vec!["Sean", "Tess"];
+    let borrowed_names: &[_] = &["Sean", "Jim"];
+    assert_eq!(vec![sean.clone(), tess],
+        users.filter(name.eq_any(owned_names)).load(&connection).unwrap());
+    assert_eq!(vec![sean, jim],
+        users.filter(name.eq_any(borrowed_names)).load(&connection).unwrap());
+}
+
 fn connection_with_3_users() -> TestConnection {
     let connection = connection_with_sean_and_tess_in_users_table();
     connection.execute("INSERT INTO users (id, name) VALUES (3, 'Jim')").unwrap();


### PR DESCRIPTION
We didn't have a use for this previously, as PG supports `= ANY` which
is more friendly to prepared statements. Since SQLite does not support
this operator, we need to fall back to `IN`. Eventually I'd like to have
this just "do the right thing" on PG, but that's out of scope for 0.5.

The name `eq_any` was chosen both to allow me to change the behavior on
PG in the future, and also because `in` is a keyword in Rust and cannot
be used as a function name.

Fixes #186