### PR TITLE
Support subselects for IN statements.

### DIFF
--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -5,11 +5,11 @@ use types::Bool;
 
 pub struct In<T, U> {
     left: T,
-    values: Vec<U>,
+    values: U,
 }
 
 impl<T, U> In<T, U> {
-    pub fn new(left: T, values: Vec<U>) -> Self {
+    pub fn new(left: T, values: U) -> Self {
         In {
             left: left,
             values: values,
@@ -33,8 +33,6 @@ impl<T, U, QS> SelectableExpression<QS> for In<T, U> where
 
 impl<T, U> NonAggregate for In<T, U> where
     In<T, U>: Expression,
-    T: NonAggregate,
-    U: NonAggregate,
 {
 }
 
@@ -46,12 +44,91 @@ impl<T, U, DB> QueryFragment<DB> for In<T, U> where
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         try!(self.left.to_sql(out));
         out.push_sql(" IN (");
-        try!(self.values[0].to_sql(out));
-        for value in self.values[1..].iter() {
+        try!(self.values.to_sql(out));
+        out.push_sql(")");
+        Ok(())
+    }
+}
+
+use std::marker::PhantomData;
+use query_builder::SelectStatement;
+
+pub trait AsInExpression<T> {
+    type InExpression: Expression<SqlType=T>;
+
+    fn as_in_expression(self) -> Self::InExpression;
+}
+
+impl<I, T, ST> AsInExpression<ST> for I where
+    I: IntoIterator<Item=T>,
+    T: AsExpression<ST>,
+{
+    type InExpression = Many<T::Expression>;
+
+    fn as_in_expression(self) -> Self::InExpression {
+        let expressions = self.into_iter()
+            .map(AsExpression::as_expression).collect();
+        Many(expressions)
+    }
+}
+
+impl<ST, S, F, W, O, L, Of> AsInExpression<ST>
+    for SelectStatement<ST, S, F, W, O, L, Of> where
+        SelectStatement<ST, S, F, W, O, L, Of>: Expression,
+{
+    type InExpression = Subselect<Self, ST>;
+
+    fn as_in_expression(self) -> Self::InExpression {
+        Subselect { values: self, _sql_type: PhantomData }
+    }
+}
+
+pub struct Many<T>(Vec<T>);
+
+impl<T: Expression> Expression for Many<T> {
+    type SqlType = T::SqlType;
+}
+
+impl<T, QS> SelectableExpression<QS> for Many<T> where
+    Many<T>: Expression,
+    T: SelectableExpression<QS>,
+{
+}
+
+impl<T, DB> QueryFragment<DB> for Many<T> where
+    DB: Backend,
+    T: QueryFragment<DB>,
+{
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        try!(self.0[0].to_sql(out));
+        for value in self.0[1..].iter() {
             out.push_sql(", ");
             try!(value.to_sql(out));
         }
-        out.push_sql(")");
         Ok(())
+    }
+}
+
+pub struct Subselect<T, ST> {
+    values: T,
+    _sql_type: PhantomData<ST>,
+}
+
+impl<T: Expression, ST> Expression for Subselect<T, ST> {
+    type SqlType = ST;
+}
+
+impl<T, ST, QS> SelectableExpression<QS> for Subselect<T, ST> where
+    Subselect<T, ST>: Expression,
+    T: SelectableExpression<QS>,
+{
+}
+
+impl<T, ST, DB> QueryFragment<DB> for Subselect<T, ST> where
+    DB: Backend,
+    T: QueryFragment<DB>,
+{
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        self.values.to_sql(out)
     }
 }

--- a/diesel/src/expression/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression/expression_methods/global_expression_methods.rs
@@ -1,6 +1,6 @@
 use expression::{Expression, AsExpression, nullable};
 use expression::aliased::Aliased;
-use expression::array_comparison::In;
+use expression::array_comparison::{In, AsInExpression};
 use expression::predicates::*;
 
 pub trait ExpressionMethods: Expression + Sized {
@@ -103,13 +103,10 @@ pub trait ExpressionMethods: Expression + Sized {
     /// assert_eq!(Ok(vec![1, 3]), data.load(&connection));
     /// # }
     /// ```
-    fn eq_any<I, T>(self, values: I) -> In<Self, T::Expression> where
-        I: IntoIterator<Item=T>,
-        T: AsExpression<Self::SqlType>,
+    fn eq_any<T>(self, values: T) -> In<Self, T::InExpression> where
+        T: AsInExpression<Self::SqlType>,
     {
-        let expressions = values.into_iter()
-            .map(AsExpression::as_expression).collect();
-        In::new(self, expressions)
+        In::new(self, values.as_in_expression())
     }
 
     /// Creates a SQL `IS NULL` expression.

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -145,7 +145,6 @@ fn selecting_columns_with_different_definition_order() {
 }
 
 #[test]
-#[cfg(feature = "postgres")] // FIXME: This test is valid for SQLite, but currently relies on `= ANY` which is PG specific
 fn selection_using_subselect() {
     use schema::posts::dsl::*;
     use diesel::expression::dsl::*;
@@ -160,7 +159,7 @@ fn selection_using_subselect() {
     let users = users::table.filter(users::name.eq("Sean")).select(users::id);
     let data: Vec<String> = posts
         .select(title)
-        .filter(user_id.eq(any(users)))
+        .filter(user_id.eq_any(users))
         .load(&connection).unwrap();
 
     assert_eq!(vec!["Hello".to_string()], data);


### PR DESCRIPTION
This is a feature that was supported by `eq(any())`, but not currently
by the in clause. The `Subselect` type was introduced to normalize the
differences between the SQL type of `SelectStatement` depending on the
backend. That implementation is a bit of a wart, regardless. We can
probably revisit this later and factor out some kind of a `Many` SQL
type which is independent of `Array`. I need to better analyze the
impact of that change though, (specifically making sure that it
continues to work with `eq(any())`), and I think it's out of scope for
0.5.