### PR TITLE
Fix remaining FIXMEs that are going to be fixed in 0.5

### DIFF
--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -8,6 +8,7 @@ pub mod load_dsl;
 pub mod select_dsl;
 #[doc(hidden)]
 pub mod filter_dsl;
+mod save_changes_dsl;
 mod offset_dsl;
 mod order_dsl;
 mod with_dsl;
@@ -19,5 +20,6 @@ pub use self::limit_dsl::LimitDsl;
 pub use self::load_dsl::{LoadDsl, ExecuteDsl};
 pub use self::offset_dsl::OffsetDsl;
 pub use self::order_dsl::OrderDsl;
+pub use self::save_changes_dsl::SaveChangesDsl;
 pub use self::select_dsl::{SelectDsl, SelectSqlDsl};
 pub use self::with_dsl::{WithDsl, WithQuerySource};

--- a/diesel/src/query_dsl/save_changes_dsl.rs
+++ b/diesel/src/query_dsl/save_changes_dsl.rs
@@ -1,0 +1,12 @@
+use connection::Connection;
+use query_source::Queryable;
+use result::QueryResult;
+use types::HasSqlType;
+
+pub trait SaveChangesDsl<Conn, ST> where
+    Conn: Connection,
+    Conn::Backend: HasSqlType<ST>,
+{
+    fn save_changes<T>(&self, connection: &Conn) -> QueryResult<T> where
+        T: Queryable<ST, Conn::Backend>;
+}

--- a/diesel/src/sqlite/types/mod.rs
+++ b/diesel/src/sqlite/types/mod.rs
@@ -1,10 +1,11 @@
 mod date_and_time;
 
+use std::io::prelude::*;
 use std::error::Error;
 
 use super::Sqlite;
 use super::connection::SqliteValue;
-use types::{self, FromSql};
+use types::{self, FromSql, ToSql, IsNull};
 
 impl FromSql<types::VarChar, Sqlite> for String {
     fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error>> {
@@ -53,5 +54,16 @@ impl FromSql<types::Float, Sqlite> for f32 {
 impl FromSql<types::Double, Sqlite> for f64 {
     fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error>> {
         Ok(not_none!(value).read_double())
+    }
+}
+
+impl ToSql<types::Bool, Sqlite> for bool {
+    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error>> {
+        let int_value = if *self {
+            1
+        } else {
+            0
+        };
+        <i32 as ToSql<types::Integer, Sqlite>>::to_sql(&int_value, out)
     }
 }

--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -24,6 +24,7 @@ default = ["with-syntex", "postgres"]
 nightly = []
 with-syntex = ["syntex", "syntex_syntax"]
 postgres = ["diesel/postgres"]
+sqlite = ["diesel/sqlite"]
 
 [lib]
 name = "diesel_codegen"

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -26,7 +26,7 @@ default = ["syntex", "diesel_codegen/with-syntex", "dotenv_codegen"]
 unstable = ["diesel_codegen/nightly", "diesel/unstable",
   "quickcheck/unstable", "dotenv_macros"]
 postgres = ["diesel/postgres", "diesel_codegen/postgres"]
-sqlite = ["diesel/sqlite"]
+sqlite = ["diesel/sqlite", "diesel_codegen/sqlite"]
 
 [[test]]
 name = "integration_tests"

--- a/diesel_tests/tests/associations.rs
+++ b/diesel_tests/tests/associations.rs
@@ -7,15 +7,15 @@ fn one_to_many_returns_query_source_for_association() {
 
     let sean = find_user_by_name("Sean", &connection);
     let tess = find_user_by_name("Tess", &connection);
-    let seans_posts: Vec<Post> =  insert(&vec![
-        sean.new_post("Hello", None), sean.new_post("World", None)
-        ]).into(posts::table)
-        .get_results(&connection)
+    let new_posts = vec![sean.new_post("Hello", None), sean.new_post("World", None)];
+    batch_insert(&new_posts, posts::table, &connection);
+    let new_posts = vec![tess.new_post("Hello 2", None), tess.new_post("World 2", None)];
+    batch_insert(&new_posts, posts::table, &connection);
+    let seans_posts = posts::table.filter(posts::user_id.eq(sean.id))
+        .load::<Post>(&connection)
         .unwrap();
-    let tess_posts: Vec<Post> = insert(&vec![
-        tess.new_post("Hello 2", None), tess.new_post("World 2", None),
-        ]).into(posts::table)
-        .get_results(&connection)
+    let tess_posts = posts::table.filter(posts::user_id.eq(tess.id))
+        .load::<Post>(&connection)
         .unwrap();
 
     let found_posts: Vec<_> = Post::belonging_to(&sean).load(&connection).unwrap();

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -88,7 +88,6 @@ fn filter_by_is_null_on_nullable_columns() {
 }
 
 #[test]
-#[cfg(feature = "postgres")] // FIXME: There are valuable tests for SQLite here
 fn filter_after_joining() {
     use schema::users::name;
 
@@ -240,7 +239,6 @@ fn filter_with_or() {
 }
 
 #[test]
-#[cfg(feature = "postgres")] // FIXME: There are valuable tests for SQLite here
 fn or_doesnt_mess_with_precidence_of_previous_statements() {
     use schema::users::dsl::*;
     use diesel::expression::AsExpression;
@@ -262,9 +260,8 @@ use diesel::types::VarChar;
 sql_function!(lower, lower_t, (x: VarChar) -> VarChar);
 
 #[test]
-#[cfg(feature = "postgres")] // FIXME: There are valuable tests for SQLite here
 fn filter_by_boxed_predicate() {
-    fn by_name(name: &str) -> Box<BoxableExpression<users::table, types::Bool, pg::Pg, SqlType=types::Bool>> {
+    fn by_name(name: &str) -> Box<BoxableExpression<users::table, types::Bool, TestBackend, SqlType=types::Bool>> {
         Box::new(lower(users::name).eq(name.to_string()))
     }
 

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -10,7 +10,6 @@ include!("lib.in.rs");
 #[cfg(not(feature = "unstable"))]
 include!(concat!(env!("OUT_DIR"), "/lib.rs"));
 
-#[cfg(feature = "postgres")] // FIXME: There are valuable tests for SQLite here
 mod associations;
 mod expressions;
 mod filter;


### PR DESCRIPTION
This adds two new missing features to `SQLite`. A `ToSql` impl for
`Bool`, and an implementation of `save_changes`. I wanted to keep the
blanket impl for `SupportsReturningKeyword`, but it looks like I can't
rely on `Sqlite` not implementing it from the user's crate. I think this
will just get moved in crate once we solve #179 anyway.

There are still some remaining things to be addressed, such as the lack
of support for numeric and date types, but those are out of scope for
0.5.

Fixes #173.