### PR TITLE
Allow the migration version to be overridden at the command line

### DIFF
--- a/diesel_cli/tests/migrations.rs
+++ b/diesel_cli/tests/migrations.rs
@@ -16,7 +16,7 @@ fn migration_generate_creates_a_migration_with_the_proper_name() {
 Creating migrations/\\d{14}_hello/up.sql
 Creating migrations/\\d{14}_hello/down.sql\
         ").unwrap();
-    assert!(result.is_success());
+    assert!(result.is_success(), "Command failed: {:?}", result);
     assert!(expected_stdout.is_match(result.stdout()));
 
     let migrations = p.migrations();
@@ -26,4 +26,26 @@ Creating migrations/\\d{14}_hello/down.sql\
     assert_eq!("hello", migration.name());
     assert!(migration.path().join("up.sql").exists());
     assert!(migration.path().join("down.sql").exists());
+}
+
+#[test]
+fn migration_version_can_be_specified_on_creation() {
+    let p = project("migration_name")
+        .folder("migrations")
+        .build();
+    let result = p.command("migration")
+        .arg("generate")
+        .arg("hello")
+        .arg("--version=1234")
+        .run();
+
+    let expected_stdout = "\
+Creating migrations/1234_hello/up.sql
+Creating migrations/1234_hello/down.sql
+";
+    assert!(result.is_success(), "Command failed: {:?}", result);
+    assert_eq!(expected_stdout, result.stdout());
+
+    assert!(p.has_file("migrations/1234_hello/up.sql"));
+    assert!(p.has_file("migrations/1234_hello/down.sql"));
 }

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -74,6 +74,10 @@ impl Project {
             .into_os_string()
             .into_string().unwrap()
     }
+
+    pub fn has_file(&self, path: &str) -> bool {
+        self.directory.path().join(path).exists()
+    }
 }
 
 #[cfg(feature = "postgres")]
@@ -98,12 +102,9 @@ pub struct Migration {
 }
 
 impl Migration {
-    pub fn version(&self) -> &str {
-        &self.file_name()[..14]
-    }
-
     pub fn name(&self) -> &str {
-        &self.file_name()[15..]
+        let name_start_index = self.file_name().find('_').unwrap() + 1;
+        &self.file_name()[name_start_index..]
     }
 
     pub fn path(&self) -> &Path {


### PR DESCRIPTION
This will make our lives much easier for testing purposes, as we don't
have to deal with timestamps (unless we're tesing something that
involves timestamps)

Review? @mcasper 