### PR TITLE
Allow the migration directory to be overridden

### DIFF
--- a/diesel_cli/tests/migrations.rs
+++ b/diesel_cli/tests/migrations.rs
@@ -49,3 +49,49 @@ Creating migrations/1234_hello/down.sql
     assert!(p.has_file("migrations/1234_hello/up.sql"));
     assert!(p.has_file("migrations/1234_hello/down.sql"));
 }
+
+#[test]
+fn migration_directory_can_be_specified_for_generate_by_command_line_arg() {
+    let p = project("migration_name")
+        .folder("foo")
+        .build();
+    let result = p.command("migration")
+        .arg("generate")
+        .arg("stuff")
+        .arg("--version=12345")
+        .arg("--migration-dir=foo")
+        .run();
+
+    let expected_stdout = "\
+Creating foo/12345_stuff/up.sql
+Creating foo/12345_stuff/down.sql
+";
+    assert!(result.is_success(), "Command failed: {:?}", result);
+    assert_eq!(expected_stdout, result.stdout());
+
+    assert!(p.has_file("foo/12345_stuff/up.sql"));
+    assert!(p.has_file("foo/12345_stuff/down.sql"));
+}
+
+#[test]
+fn migration_directory_can_be_specified_for_generate_by_env_var() {
+    let p = project("migration_name")
+        .folder("bar")
+        .build();
+    let result = p.command("migration")
+        .arg("generate")
+        .arg("stuff")
+        .arg("--version=12345")
+        .env("MIGRATION_DIRECTORY", "bar")
+        .run();
+
+    let expected_stdout = "\
+Creating bar/12345_stuff/up.sql
+Creating bar/12345_stuff/down.sql
+";
+    assert!(result.is_success(), "Command failed: {:?}", result);
+    assert_eq!(expected_stdout, result.stdout());
+
+    assert!(p.has_file("bar/12345_stuff/up.sql"));
+    assert!(p.has_file("bar/12345_stuff/down.sql"));
+}

--- a/diesel_cli/tests/migrations.rs
+++ b/diesel_cli/tests/migrations.rs
@@ -16,7 +16,7 @@ fn migration_generate_creates_a_migration_with_the_proper_name() {
 Creating migrations/\\d{14}_hello/up.sql
 Creating migrations/\\d{14}_hello/down.sql\
         ").unwrap();
-    assert!(result.is_success());
+    assert!(result.is_success(), "Command failed: {:?}", result);
     assert!(expected_stdout.is_match(result.stdout()));
 
     let migrations = p.migrations();
@@ -26,4 +26,26 @@ Creating migrations/\\d{14}_hello/down.sql\
     assert_eq!("hello", migration.name());
     assert!(migration.path().join("up.sql").exists());
     assert!(migration.path().join("down.sql").exists());
+}
+
+#[test]
+fn migration_version_can_be_specified_on_creation() {
+    let p = project("migration_name")
+        .folder("migrations")
+        .build();
+    let result = p.command("migration")
+        .arg("generate")
+        .arg("hello")
+        .arg("--version=1234")
+        .run();
+
+    let expected_stdout = "\
+Creating migrations/1234_hello/up.sql
+Creating migrations/1234_hello/down.sql
+";
+    assert!(result.is_success(), "Command failed: {:?}", result);
+    assert_eq!(expected_stdout, result.stdout());
+
+    assert!(p.has_file("migrations/1234_hello/up.sql"));
+    assert!(p.has_file("migrations/1234_hello/down.sql"));
 }

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -74,6 +74,10 @@ impl Project {
             .into_os_string()
             .into_string().unwrap()
     }
+
+    pub fn has_file(&self, path: &str) -> bool {
+        self.directory.path().join(path).exists()
+    }
 }
 
 #[cfg(feature = "postgres")]
@@ -98,12 +102,9 @@ pub struct Migration {
 }
 
 impl Migration {
-    pub fn version(&self) -> &str {
-        &self.file_name()[..14]
-    }
-
     pub fn name(&self) -> &str {
-        &self.file_name()[15..]
+        let name_start_index = self.file_name().find('_').unwrap() + 1;
+        &self.file_name()[name_start_index..]
     }
 
     pub fn path(&self) -> &Path {


### PR DESCRIPTION
This currently only affects the generator, as we don't have tests for the other commands yet. This is to allow us to use CLI on our own codebase again, as we have a non-standard migration directory structure.

This relies on #203.

Review? @mcasper 