### PR TITLE
`diesel migration generate` shouldn't require a DATABASE_URL to be set

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -104,18 +104,19 @@ fn main() {
 }
 
 fn run_migration_command(matches: &ArgMatches) {
-    let database_url = database::database_url(matches);
-
     match matches.subcommand() {
         ("run", Some(_)) => {
+            let database_url = database::database_url(matches);
             call_with_conn!(database_url, migrations::run_pending_migrations)
                 .unwrap_or_else(handle_error);
         }
         ("revert", Some(_)) => {
+            let database_url = database::database_url(matches);
             call_with_conn!(database_url, migrations::revert_latest_migration)
                 .unwrap_or_else(handle_error);
         }
         ("redo", Some(_)) => {
+            let database_url = database::database_url(matches);
             call_with_conn!(database_url, redo_latest_migration);
         }
         ("generate", Some(args)) => {

--- a/diesel_cli/tests/migrations.rs
+++ b/diesel_cli/tests/migrations.rs
@@ -29,6 +29,25 @@ Creating migrations/\\d{14}_hello/down.sql\
 }
 
 #[test]
+fn migration_generate_doesnt_require_database_url_to_be_set() {
+    let p = project("migration_name")
+        .folder("migrations")
+        .build();
+    let result = p.command("migration")
+        .arg("generate")
+        .arg("hello")
+        .remove_env("DATABASE_URL")
+        .run();
+
+    let expected_stdout = Regex::new("\
+Creating migrations/\\d{14}_hello/up.sql
+Creating migrations/\\d{14}_hello/down.sql\
+        ").unwrap();
+    assert!(result.is_success(), "Command failed: {:?}", result);
+    assert!(expected_stdout.is_match(result.stdout()));
+}
+
+#[test]
 fn migration_version_can_be_specified_on_creation() {
     let p = project("migration_name")
         .folder("migrations")

--- a/diesel_cli/tests/support/command.rs
+++ b/diesel_cli/tests/support/command.rs
@@ -28,6 +28,17 @@ impl TestCommand {
         self
     }
 
+    pub fn remove_env(mut self, key: &str) -> Self {
+        let mut index = None;
+        for (i, &(ref k, ref _v)) in self.env_vars.iter().enumerate() {
+            if k == key {
+                index = Some(i)
+            }
+        }
+        index.map(|i| self.env_vars.remove(i));
+        self
+    }
+
     pub fn run(self) -> CommandResult {
         let output = self.build_command().output().unwrap();
         CommandResult {


### PR DESCRIPTION
This got inadvertently introduced in my SQLite support branch. Even
though pretty much every command after this one requires a DATABASE_URL,
I think it's unintuitive to require one here (and wasn't the previous
use case).