### PR TITLE
Remove the hard dependencies on SQLite and Postgres from CLI

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -15,7 +15,7 @@ name = "diesel"
 [dependencies]
 chrono = "0.2.17"
 clap = "1.5.5"
-diesel = { version = "0.5.0", features = ["postgres", "sqlite"] }
+diesel = { version = "0.5.0", default-features = false }
 dotenv = "0.8.0"
 
 [dev-dependencies]
@@ -23,6 +23,7 @@ tempdir = "0.3.4"
 regex = "0.1.48"
 
 [features]
+default = ["postgres", "sqlite"]
 postgres = ["diesel/postgres"]
 sqlite = ["diesel/sqlite"]
 

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -9,7 +9,9 @@ mod database;
 
 use chrono::*;
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
+#[cfg(feature = "postgres")]
 use diesel::pg::PgConnection;
+#[cfg(feature = "sqlite")]
 use diesel::sqlite::SqliteConnection;
 use diesel::migrations::schema::*;
 use diesel::types::{FromSql, VarChar};


### PR DESCRIPTION
Right now it's impossible to install Diesel CLI on your system if you
don't have both of these dependencies installed. This continues to
support both by default, but allows you to opt out of one of them if you
specifically need to.

This differs from our other crates where we only target Postgres by
default. However, I want `cargo install diesel_cli` to "just work", and
this case doesn't affect the binary size or memory usage of your actual
application.

Fixes #205

Review? @mcasper