### PR TITLE
Fix `diesel database setup` help, and specify subgroup help messages

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -35,6 +35,8 @@ fn main() {
         .takes_value(true);
 
     let migration_subcommand = SubCommand::with_name("migration")
+        .about("A group of commands for generating, running, and reverting \
+                migrations.")
         .setting(AppSettings::VersionlessSubcommands)
         .arg(Arg::with_name("MIGRATION_DIRECTORY")
             .long("migration-dir")
@@ -75,24 +77,26 @@ fn main() {
                 specified in your DATABASE_URL, and runs existing migrations.");
 
     let database_subcommand = SubCommand::with_name("database")
+        .about("A group of commands for setting up and resetting your database.")
         .setting(AppSettings::VersionlessSubcommands)
         .subcommand(
             SubCommand::with_name("setup")
-                .about("Creates the migrations directory, creates the database \
-                        specified in your DATABASE_URL, and runs existing migrations.")
+                .about("Creates the database specified in your DATABASE_URL, \
+                        and then runs any existing migrations.")
         ).subcommand(
             SubCommand::with_name("reset")
                 .about("Resets your database by dropping the database specified \
                         in your DATABASE_URL and then running `diesel database setup`.")
         ).subcommand(
             SubCommand::with_name("drop")
-                .about("Drops the database specified in your DATABASE_URL")
+                .about("Drops the database specified in your DATABASE_URL.")
                 .setting(AppSettings::Hidden)
         ).setting(AppSettings::SubcommandRequiredElseHelp);
 
     let matches = App::new("diesel")
         .version(env!("CARGO_PKG_VERSION"))
         .setting(AppSettings::VersionlessSubcommands)
+        .after_help("You can also run `diesel SUBCOMMAND -h` to get more information about that subcommand.")
         .arg(database_arg)
         .subcommand(migration_subcommand)
         .subcommand(setup_subcommand)


### PR DESCRIPTION
Right now the help message for `diesel database setup` shows the same exact thing as `diesel setup`, which is incorrect (`database setup` doesn't create the migrations directory for you). 

I also added descriptions for subcommand groups to make the top level `help` look more cohesive.

Before
```
diesel 0.5.1

USAGE:
        diesel [FLAGS] [OPTIONS] [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --database-url <DATABASE_URL>    Specifies the database URL to connect to. Falls back to the DATABASE_URL environment variable if unspecified.

SUBCOMMANDS:
    database
    help         Prints this message
    migration
    setup        Creates the migrations directory, creates the database specified in your DATABASE_URL, and runs existing migrations.
```
After
```
diesel 0.5.1

USAGE:
        diesel [FLAGS] [OPTIONS] [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --database-url <DATABASE_URL>    Specifies the database URL to connect to. Falls back to the DATABASE_URL environment variable if unspecified.

SUBCOMMANDS:
    database     A group of commands for setting up and resetting your database.
    help         Prints this message
    migration    A group of commands for generating, running, and reverting migrations.
    setup        Creates the migrations directory, creates the database specified in your DATABASE_URL, and runs existing migrations.
```