### PR TITLE
Add `#into_boxed` to all queries, for conditional changes

### DIFF
--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -18,7 +18,7 @@ pub mod insert_statement;
 pub mod update_statement;
 
 #[doc(hidden)]
-pub use self::select_statement::SelectStatement;
+pub use self::select_statement::{SelectStatement, BoxedSelectStatement};
 #[doc(inline)]
 pub use self::update_statement::{IncompleteUpdateStatement, AsChangeset, Changeset, UpdateTarget};
 #[doc(inline)]

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -1,0 +1,62 @@
+use std::marker::PhantomData;
+
+use backend::Backend;
+use query_builder::*;
+use query_source::QuerySource;
+use types::HasSqlType;
+
+pub struct BoxedSelectStatement<ST, QS, DB> {
+    select: Box<QueryFragment<DB>>,
+    from: QS,
+    where_clause: Box<QueryFragment<DB>>,
+    order: Box<QueryFragment<DB>>,
+    limit: Box<QueryFragment<DB>>,
+    offset: Box<QueryFragment<DB>>,
+    _marker: PhantomData<(ST, DB)>,
+}
+
+impl<ST, QS, DB> BoxedSelectStatement<ST, QS, DB> {
+    pub fn new(
+        select: Box<QueryFragment<DB>>,
+        from: QS,
+        where_clause: Box<QueryFragment<DB>>,
+        order: Box<QueryFragment<DB>>,
+        limit: Box<QueryFragment<DB>>,
+        offset: Box<QueryFragment<DB>>,
+    ) -> Self {
+        BoxedSelectStatement {
+            select: select,
+            from: from,
+            where_clause: where_clause,
+            order: order,
+            limit: limit,
+            offset: offset,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<ST, QS, DB> Query for BoxedSelectStatement<ST, QS, DB> where
+    DB: Backend,
+    DB: HasSqlType<ST>,
+{
+    type SqlType = ST;
+}
+
+impl<ST, QS, DB> QueryFragment<DB> for BoxedSelectStatement<ST, QS, DB> where
+    DB: Backend,
+    QS: QuerySource,
+    QS::FromClause: QueryFragment<DB>,
+{
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        out.push_sql("SELECT ");
+        try!(self.select.to_sql(out));
+        out.push_sql(" FROM ");
+        try!(self.from.from_clause().to_sql(out));
+        try!(self.where_clause.to_sql(out));
+        try!(self.order.to_sql(out));
+        try!(self.limit.to_sql(out));
+        try!(self.offset.to_sql(out));
+        Ok(())
+    }
+}

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -1,15 +1,19 @@
 mod dsl_impls;
+mod boxed;
+
+pub use self::boxed::BoxedSelectStatement;
+
+use std::marker::PhantomData;
 
 use backend::Backend;
 use expression::*;
 use query_source::*;
-use std::marker::PhantomData;
-use super::{Query, QueryBuilder, QueryFragment, BuildQueryResult};
 use super::group_by_clause::NoGroupByClause;
 use super::limit_clause::NoLimitClause;
 use super::offset_clause::NoOffsetClause;
 use super::order_clause::NoOrderClause;
 use super::where_clause::NoWhereClause;
+use super::{Query, QueryBuilder, QueryFragment, BuildQueryResult};
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]

--- a/diesel/src/query_dsl/boxed_dsl.rs
+++ b/diesel/src/query_dsl/boxed_dsl.rs
@@ -1,0 +1,21 @@
+use backend::Backend;
+use query_builder::AsQuery;
+use query_source::QuerySource;
+
+pub trait BoxedDsl<DB: Backend> {
+    type Output;
+
+    fn into_boxed(self) -> Self::Output;
+}
+
+impl<T, DB> BoxedDsl<DB> for T where
+    DB: Backend,
+    T: QuerySource + AsQuery,
+    T::Query: BoxedDsl<DB>,
+{
+    type Output = <T::Query as BoxedDsl<DB>>::Output;
+
+    fn into_boxed(self) -> Self::Output {
+        self.as_query().into_boxed()
+    }
+}

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -1,4 +1,5 @@
 mod belonging_to_dsl;
+mod boxed_dsl;
 mod count_dsl;
 mod group_by_dsl;
 #[doc(hidden)]
@@ -15,6 +16,7 @@ mod order_dsl;
 mod with_dsl;
 
 pub use self::belonging_to_dsl::BelongingToDsl;
+pub use self::boxed_dsl::BoxedDsl;
 pub use self::count_dsl::CountDsl;
 pub use self::filter_dsl::{FilterDsl, FindDsl};
 #[doc(hidden)]

--- a/diesel_tests/tests/boxed_queries.rs
+++ b/diesel_tests/tests/boxed_queries.rs
@@ -1,0 +1,64 @@
+use super::schema::*;
+use diesel::*;
+use diesel::query_builder::BoxedSelectStatement;
+
+#[test]
+fn boxed_queries_can_be_executed() {
+    let connection = connection_with_sean_and_tess_in_users_table();
+    insert(&NewUser::new("Jim", None)).into(users::table)
+        .execute(&connection).unwrap();
+    let query_which_fails_unless_all_segments_are_applied =
+        users::table
+            .select(users::name)
+            .filter(users::name.ne("jim"))
+            .order(users::name.desc())
+            .limit(1)
+            .offset(1)
+            .into_boxed();
+
+    let expected_data = vec!["Sean".to_string()];
+    let data = query_which_fails_unless_all_segments_are_applied.load(&connection);
+    assert_eq!(Ok(expected_data), data);
+}
+
+#[test]
+fn boxed_queries_can_differ_conditionally() {
+    let connection = connection_with_sean_and_tess_in_users_table();
+    insert(&NewUser::new("Jim", None)).into(users::table)
+        .execute(&connection).unwrap();
+
+    enum Query { All, Ordered, One };
+    fn source(query: Query)
+        -> BoxedSelectStatement<users::SqlType, users::table, TestBackend>
+    {
+        match query {
+            Query::All => users::table.into_boxed(),
+            Query::Ordered =>
+                users::table
+                    .order(users::name.desc())
+                    .into_boxed(),
+            Query::One =>
+                users::table
+                    .filter(users::name.ne("jim"))
+                    .order(users::name.desc())
+                    .limit(1)
+                    .offset(1)
+                    .into_boxed(),
+        }
+    }
+    let sean = find_user_by_name("Sean", &connection);
+    let tess = find_user_by_name("Tess", &connection);
+    let jim = find_user_by_name("Jim", &connection);
+
+    let all = source(Query::All).load(&connection);
+    let expected_data = vec![sean.clone(), tess.clone(), jim.clone()];
+    assert_eq!(Ok(expected_data), all);
+
+    let ordered = source(Query::Ordered).load(&connection);
+    let expected_data = vec![tess.clone(), sean.clone(), jim.clone()];
+    assert_eq!(Ok(expected_data), ordered);
+
+    let one = source(Query::One).load(&connection);
+    let expected_data = vec![sean.clone()];
+    assert_eq!(Ok(expected_data), one);
+}

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -11,8 +11,10 @@ include!("lib.in.rs");
 include!(concat!(env!("OUT_DIR"), "/lib.rs"));
 
 mod associations;
-mod expressions;
+mod boxed_queries;
 mod connection;
+mod debug;
+mod expressions;
 mod filter;
 mod filter_operators;
 mod find;
@@ -27,4 +29,3 @@ mod select;
 mod transactions;
 mod types;
 mod types_roundtrip;
-mod debug;


### PR DESCRIPTION
This is the first pass of what will be a much larger feature. The
intention is to support cases such as this:

```rust
let mut source = users::table.into_boxed();

if let Some(search) = params.search {
    source = source.filter(name.like(format!("%{}%", search)));
}

if let Some(order) = column_with_name(params.order) {
    source = source.order(order.desc());
}

let users = source.load(&connection);
```

Right now, this is basically impossible, as `source` needs to have the
same type, and each query in diesel has a unique type. This *will*
result in a slowdown of the query builder when used (though I think we
can still work to eliminate this cost through prepared statement
caching). However, this will not affect the performance of anything that
isn't using it.

As of this commit, we do not achieve the above use case, as
`BoxedSelectStatement` doesn't implement any of our query DSLs. The
intent is to have it implement all of them, but this felt like a good
place to cut a first pass.

This will fail to compile due to
https://github.com/rust-lang/rust/issues/32222. We can resolve this by
pointing at `nightly-2016-03-05` if needed, but hopefully that can be
resolved upstream in the next day or two.