### PR TITLE
Print error and exit 1 instead of panicking in CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,10 @@ script:
 env:
   matrix:
     - BACKEND=sqlite
+      DATABASE_URL=/tmp/test.db
     - BACKEND=postgres
+      DATABASE_URL=postgres://postgres@localhost/
   global:
-    - DATABASE_URL=postgres://postgres@localhost/
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""
     - secure: NmCM1VNEzid6bROA7tXV1R63n9S9KvY1etXsDzd1608cvjRnG3ZDAWXISbY1BxqrvleElreUJOvz/3TSQCHivpT2ezeyk2sntYtZpw0TWbz1SQMAPNWPTjP3bNQzpmNwfU4p6ui6qIOnQza4JxOu3SZSveNlehDBPkkS+52R7Zw/EPdwi9jTYJArV2+8pnEsQECAdRLttbtA2JBl3hZ4VHfGpHRZyeULn63UzyVbQVzQ3NVhqyQUKTPdpUciQTI3fZEkfaWuLV8QPPa5026/yJEEi2Fsl3r7fyY8ia67k4Zo9THlPVD0YOUlkWuZWwvkxNA8RQSVPv4FidEpwbxG8y6nAra4CjwiEChcpFhZJtrH7ZrXO/tJk7vtc5CFVWUsQtNX92QY1QFdPxwYNBSICLyUN+A+BQURwvQgxdcJsJyQmh5Ed7yuavcAinVq7fPeOyBWcPL5mt17no16aG1rzvXSUnD0aH7F3S3DHkoM9P9iHgJMLk+2YNmJtFescBxCeG8bA7t5bw0kQNH5KUWAD1uYpC9ikB3NVdlc+q17dKTAe4rcYA+sIO+UGudvpmLWT0lXtEMqDfxfCmyICDESs9bNfueCGJEAnfTBNunsJqR7rMUvjNndS2/Ssok6c/0Yfb9X8cM9nI4QLAj/+hClqdYphmpCjuC34bWxFSt/KJI=
 matrix:

--- a/diesel_cli/src/database_error.rs
+++ b/diesel_cli/src/database_error.rs
@@ -12,6 +12,7 @@ pub type DatabaseResult<T> = Result<T, DatabaseError>;
 pub enum DatabaseError {
     #[allow(dead_code)]
     CargoTomlNotFound,
+    DatabaseUrlMissing,
     IoError(io::Error),
     QueryError(result::Error),
     ConnectionError(result::ConnectionError),
@@ -39,6 +40,7 @@ impl Error for DatabaseError {
     fn description(&self) -> &str {
         match *self {
             CargoTomlNotFound => "Unable to find Cargo.toml in this directory or any parent directories.",
+            DatabaseUrlMissing => "The --database-url argument must be passed, or the DATABASE_URL environment variable must be set.",
             IoError(ref error) => error.cause().map(|e| e.description()).unwrap_or(error.description()),
             QueryError(ref error) => error.cause().map(|e| e.description()).unwrap_or(error.description()),
             ConnectionError(ref error) => error.cause().map(|e| e.description()).unwrap_or(error.description()),

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -232,7 +232,8 @@ fn redo_latest_migration<Conn>(conn: &Conn) where
 }
 
 fn handle_error<E: Error, T>(error: E) -> T {
-    panic!("{}", error);
+    println!("{}", error);
+    ::std::process::exit(1);
 }
 
 // Converts an absolute path to a relative path, with the restriction that the

--- a/diesel_cli/tests/exit_codes.rs
+++ b/diesel_cli/tests/exit_codes.rs
@@ -1,0 +1,29 @@
+use support::{database, project};
+
+#[test]
+fn errors_dont_cause_panic() {
+    let p = project("errors_dont_panic").build();
+
+    let result = p.command_without_database_url("migration").arg("run").run();
+
+    assert!(!result.is_success());
+    assert!(!result.stdout().contains("thread '<main>' panicked at"))
+}
+
+#[test]
+fn errors_exit_code_is_1() {
+    let p = project("errors_exit_1").build();
+
+    let result = p.command_without_database_url("migration").arg("run").run();
+
+    assert_eq!(1, result.code())
+}
+
+#[test]
+fn successful_run_exits_0() {
+    let p = project("successes_exit_0").build();
+
+    let result = p.command("setup").run();
+
+    assert_eq!(0, result.code())
+}

--- a/diesel_cli/tests/migration_generate.rs
+++ b/diesel_cli/tests/migration_generate.rs
@@ -33,7 +33,7 @@ fn migration_generate_doesnt_require_database_url_to_be_set() {
     let p = project("migration_name")
         .folder("migrations")
         .build();
-    let result = p.command_without_datatabase_url("migration")
+    let result = p.command_without_database_url("migration")
         .arg("generate")
         .arg("hello")
         .run();

--- a/diesel_cli/tests/support/command.rs
+++ b/diesel_cli/tests/support/command.rs
@@ -62,6 +62,10 @@ impl CommandResult {
     pub fn stderr(&self) -> &str {
         str::from_utf8(&self.output.stderr).unwrap()
     }
+
+    pub fn code(&self) -> i32 {
+        self.output.status.code().unwrap()
+    }
 }
 
 fn path_to_diesel_cli() -> PathBuf {

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -50,11 +50,11 @@ pub struct Project {
 
 impl Project {
     pub fn command(&self, name: &str) -> TestCommand {
-        self.command_without_datatabase_url(name)
+        self.command_without_database_url(name)
             .env("DATABASE_URL", &self.database_url())
     }
 
-    pub fn command_without_datatabase_url(&self, name: &str) -> TestCommand {
+    pub fn command_without_database_url(&self, name: &str) -> TestCommand {
         TestCommand::new(self.directory.path(), name)
     }
 

--- a/diesel_cli/tests/tests.rs
+++ b/diesel_cli/tests/tests.rs
@@ -11,3 +11,4 @@ mod migration_run;
 mod database_drop;
 mod database_setup;
 mod database_reset;
+mod exit_codes;


### PR DESCRIPTION
This was removed earlier because if a diesel_cli test started failing,
it would abort the entire test suite because it exited with a status
code of 1, which rust interprets as a problem. Now, because we shell out
all our tests that ever hit this part of the code, we can go back to
printing errors and exiting 1. This presentation is much nicer than a
panic.