### PR TITLE
Allow omitting the return type from `sql_function!`

### DIFF
--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -101,7 +101,11 @@ macro_rules! sql_function {
     ($fn_name:ident, $struct_name:ident, ($($arg_name:ident: $arg_type:ty),*) -> $return_type:ty,
     $docs: expr) => {
         sql_function_body!($fn_name, $struct_name, ($($arg_name: $arg_type),*) -> $return_type, $docs);
-    }
+    };
+
+    ($fn_name:ident, $struct_name:ident, ($($arg_name:ident: $arg_type:ty),*)) => {
+        sql_function!($fn_name, $struct_name, ($($arg_name: $arg_type),*) -> ());
+    };
 }
 
 #[macro_export]

--- a/diesel_tests/tests/macros.rs
+++ b/diesel_tests/tests/macros.rs
@@ -5,7 +5,7 @@
 #![cfg(feature = "postgres")]
 use schema::*;
 use diesel::*;
-use diesel::types::VarChar;
+use diesel::types::{VarChar, BigInt};
 
 sql_function!(my_lower, my_lower_t, (x: VarChar) -> VarChar);
 
@@ -24,4 +24,16 @@ fn test_sql_function() {
         .load(&connection).unwrap());
     assert_eq!(vec![tess], users.filter(my_lower(name).eq("tess"))
         .load(&connection).unwrap());
+}
+
+sql_function!(setval, setval_t, (x: VarChar, y: BigInt));
+sql_function!(currval, currval_t, (x: VarChar) -> BigInt);
+
+#[test]
+fn sql_function_without_return_type() {
+    let connection = connection();
+    select(setval("users_id_seq", 54)).execute(&connection).unwrap();
+
+    let seq_val = select(currval("users_id_seq")).get_result::<i64>(&connection);
+    assert_eq!(Ok(54), seq_val);
 }


### PR DESCRIPTION
I've been debugging the build failures, and realized that I wanted this
functionality. Seems like an oversight not to have it. Forcing `-> ()`
is a pain.