### PR TITLE
Fix CLI connection to the postgres database

### DIFF
--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -163,7 +163,7 @@ pub fn backend(database_url: &String) -> &str {
 fn split_pg_connection_string(database_url: &String) -> (String, String) {
     let mut split: Vec<&str> = database_url.split("/").collect();
     let database = split.pop().unwrap();
-    let postgres_url = split.join("/");
+    let postgres_url = format!("{}/{}", split.join("/"), "postgres");
     (database.to_owned(), postgres_url)
 }
 
@@ -179,8 +179,18 @@ mod tests {
     #[test]
     fn split_pg_connection_string_returns_postgres_url_and_database() {
         let database = "database".to_owned();
-        let postgres_url = "postgresql://localhost:5432".to_owned();
-        let database_url = format!("{}/{}", postgres_url, database);
+        let base_url = "postgresql://localhost:5432".to_owned();
+        let database_url = format!("{}/{}", base_url, database);
+        let postgres_url = format!("{}/{}", base_url, "postgres");
+        assert_eq!((database, postgres_url), split_pg_connection_string(&database_url));
+    }
+
+    #[test]
+    fn split_pg_connection_string_handles_user_and_password() {
+        let database = "database".to_owned();
+        let base_url = "postgresql://user:password@localhost:5432".to_owned();
+        let database_url = format!("{}/{}", base_url, database);
+        let postgres_url = format!("{}/{}", base_url, "postgres");
         assert_eq!((database, postgres_url), split_pg_connection_string(&database_url));
     }
 }

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -45,7 +45,7 @@ impl ProjectBuilder {
 
 pub struct Project {
     directory: TempDir,
-    name: String,
+    pub name: String,
 }
 
 impl Project {


### PR DESCRIPTION
We connect to the postgres database to create/drop databases, but when
the user supplied a username and password, we would connect to
postgres://user:pass@localhost, which postgres assumes means you also want
to connect to the `user` database. So, now we are always explicit about
what database we're connecting to.

Resolves #247 