### PR TITLE
Add support for the `DISTINCT` keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * The maximum table size can be increased to 52 by enabling the `huge-tables`
   feature. This feature will substantially increase compile times.
 
+* The `DISTINCT` keyword can now be added to queries via the `distinct()`
+  method.
+
 ### Changed
 
 * `diesel::result::Error` now implements `Send` and `Sync`. This required a

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -56,6 +56,7 @@ fn establish_connection() -> diesel::sqlite::SqliteConnection {
     connection
 }
 
+#[derive(Clone)]
 struct NewUser {
     name: String,
 }

--- a/diesel/src/query_builder/distinct_clause.rs
+++ b/diesel/src/query_builder/distinct_clause.rs
@@ -1,0 +1,20 @@
+use backend::Backend;
+use query_builder::{QueryFragment, QueryBuilder, BuildQueryResult};
+
+#[derive(Debug, Clone, Copy)]
+pub struct NoDistinctClause;
+#[derive(Debug, Clone, Copy)]
+pub struct DistinctClause;
+
+impl<DB: Backend> QueryFragment<DB> for NoDistinctClause {
+    fn to_sql(&self, _out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        Ok(())
+    }
+}
+
+impl<DB: Backend> QueryFragment<DB> for DistinctClause {
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        out.push_sql("DISTINCT ");
+        Ok(())
+    }
+}

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -8,6 +8,7 @@ pub mod functions;
 pub mod nodes;
 #[macro_use]
 mod clause_macro;
+mod distinct_clause;
 mod group_by_clause;
 mod limit_clause;
 mod offset_clause;

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -10,6 +10,7 @@ use types::{HasSqlType, Bool};
 pub struct BoxedSelectStatement<ST, QS, DB> {
     select: Box<QueryFragment<DB>>,
     from: QS,
+    distinct: Box<QueryFragment<DB>>,
     where_clause: Option<Box<QueryFragment<DB>>>,
     order: Box<QueryFragment<DB>>,
     limit: Box<QueryFragment<DB>>,
@@ -21,6 +22,7 @@ impl<ST, QS, DB> BoxedSelectStatement<ST, QS, DB> {
     pub fn new(
         select: Box<QueryFragment<DB>>,
         from: QS,
+        distinct: Box<QueryFragment<DB>>,
         where_clause: Option<Box<QueryFragment<DB>>>,
         order: Box<QueryFragment<DB>>,
         limit: Box<QueryFragment<DB>>,
@@ -29,6 +31,7 @@ impl<ST, QS, DB> BoxedSelectStatement<ST, QS, DB> {
         BoxedSelectStatement {
             select: select,
             from: from,
+            distinct: distinct,
             where_clause: where_clause,
             order: order,
             limit: limit,
@@ -52,6 +55,7 @@ impl<ST, QS, DB> QueryFragment<DB> for BoxedSelectStatement<ST, QS, DB> where
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_sql("SELECT ");
+        try!(self.distinct.to_sql(out));
         try!(self.select.to_sql(out));
         out.push_sql(" FROM ");
         try!(self.from.from_clause().to_sql(out));
@@ -82,6 +86,7 @@ impl<ST, QS, DB, Type, Selection> SelectDsl<Selection, Type>
         BoxedSelectStatement::new(
             Box::new(selection),
             self.from,
+            self.distinct,
             self.where_clause,
             self.order,
             self.limit,

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -1,6 +1,7 @@
 use backend::Backend;
 use expression::*;
 use expression::aliased::Aliased;
+use query_builder::distinct_clause::DistinctClause;
 use query_builder::group_by_clause::*;
 use query_builder::limit_clause::*;
 use query_builder::offset_clause::*;
@@ -12,112 +13,190 @@ use query_dsl::boxed_dsl::InternalBoxedDsl;
 use super::BoxedSelectStatement;
 use types::{self, Bool};
 
-impl<ST, S, F, W, O, L, Of, G, Selection, Type> SelectDsl<Selection, Type>
-    for SelectStatement<ST, S, F, W, O, L, Of, G> where
-    Selection: Expression,
-    SelectStatement<Type, Selection, F, W, O, L, Of, G>: Query<SqlType=Type>,
+impl<ST, S, F, D, W, O, L, Of, G, Selection, Type> SelectDsl<Selection, Type>
+    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
+        Selection: Expression,
+        SelectStatement<Type, Selection, F, D, W, O, L, Of, G>: Query<SqlType=Type>,
 {
-    type Output = SelectStatement<Type, Selection, F, W, O, L, Of, G>;
+    type Output = SelectStatement<Type, Selection, F, D, W, O, L, Of, G>;
 
     fn select(self, selection: Selection) -> Self::Output {
-        SelectStatement::new(selection, self.from, self.where_clause, self.order,
-            self.limit, self.offset, self.group_by)
+        SelectStatement::new(
+            selection,
+            self.from,
+            self.distinct,
+            self.where_clause,
+            self.order,
+            self.limit,
+            self.offset,
+            self.group_by,
+        )
     }
 }
 
-impl<ST, S, F, W, O, L, Of, G, Predicate> FilterDsl<Predicate>
-    for SelectStatement<ST, S, F, W, O, L, Of, G> where
-    Predicate: SelectableExpression<F, SqlType=Bool> + NonAggregate,
-    W: WhereAnd<Predicate>,
-    SelectStatement<ST, S, F, W::Output, O, L, Of, G>: Query,
+impl<ST, S, F, D, W, O, L, Of, G> DistinctDsl
+    for SelectStatement<ST, S, F, D, W, O, L, Of, G>
 {
-    type Output = SelectStatement<ST, S, F, W::Output, O, L, Of, G>;
+    type Output = SelectStatement<ST, S, F, DistinctClause, W, O, L, Of, G>;
+
+    fn distinct(self) -> Self::Output {
+        SelectStatement::new(
+            self.select,
+            self.from,
+            DistinctClause,
+            self.where_clause,
+            self.order,
+            self.limit,
+            self.offset,
+            self.group_by,
+        )
+    }
+}
+
+impl<ST, S, F, D, W, O, L, Of, G, Predicate> FilterDsl<Predicate>
+    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
+        Predicate: SelectableExpression<F, SqlType=Bool> + NonAggregate,
+        W: WhereAnd<Predicate>,
+        SelectStatement<ST, S, F, D, W::Output, O, L, Of, G>: Query,
+{
+    type Output = SelectStatement<ST, S, F, D, W::Output, O, L, Of, G>;
 
     fn filter(self, predicate: Predicate) -> Self::Output {
-        SelectStatement::new(self.select, self.from, self.where_clause.and(predicate),
-            self.order, self.limit, self.offset, self.group_by)
+        SelectStatement::new(
+            self.select,
+            self.from,
+            self.distinct,
+            self.where_clause.and(predicate),
+            self.order,
+            self.limit,
+            self.offset,
+            self.group_by,
+        )
     }
 }
 
-impl<ST, S, F, W, O, L, Of, G, Expr> OrderDsl<Expr>
-    for SelectStatement<ST, S, F, W, O, L, Of, G> where
-    Expr: SelectableExpression<F>,
-    SelectStatement<ST, S, F, W, OrderClause<Expr>, L, Of, G>: Query<SqlType=ST>,
+impl<ST, S, F, D, W, O, L, Of, G, Expr> OrderDsl<Expr>
+    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
+        Expr: SelectableExpression<F>,
+        SelectStatement<ST, S, F, D, W, OrderClause<Expr>, L, Of, G>: Query<SqlType=ST>,
 {
-    type Output = SelectStatement<ST, S, F, W, OrderClause<Expr>, L, Of, G>;
+    type Output = SelectStatement<ST, S, F, D, W, OrderClause<Expr>, L, Of, G>;
 
     fn order(self, expr: Expr) -> Self::Output {
         let order = OrderClause(expr);
-        SelectStatement::new(self.select, self.from, self.where_clause, order,
-            self.limit, self.offset, self.group_by)
+        SelectStatement::new(
+            self.select,
+            self.from,
+            self.distinct,
+            self.where_clause,
+            order,
+            self.limit,
+            self.offset,
+            self.group_by,
+        )
     }
 }
 
 #[doc(hidden)]
 pub type Limit = <i64 as AsExpression<types::BigInt>>::Expression;
 
-impl<ST, S, F, W, O, L, Of, G> LimitDsl for SelectStatement<ST, S, F, W, O, L, Of, G> where
-    SelectStatement<ST, S, F, W, O, LimitClause<Limit>, Of, G>: Query<SqlType=ST>,
+impl<ST, S, F, D, W, O, L, Of, G> LimitDsl
+    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
+        SelectStatement<ST, S, F, D, W, O, LimitClause<Limit>, Of, G>: Query<SqlType=ST>,
 {
-    type Output = SelectStatement<ST, S, F, W, O, LimitClause<Limit>, Of, G>;
+    type Output = SelectStatement<ST, S, F, D, W, O, LimitClause<Limit>, Of, G>;
 
     fn limit(self, limit: i64) -> Self::Output {
         let limit_clause = LimitClause(AsExpression::<types::BigInt>::as_expression(limit));
-        SelectStatement::new(self.select, self.from, self.where_clause,
-            self.order, limit_clause, self.offset, self.group_by)
+        SelectStatement::new(
+            self.select,
+            self.from,
+            self.distinct,
+            self.where_clause,
+            self.order,
+            limit_clause,
+            self.offset,
+            self.group_by,
+        )
     }
 }
 
 #[doc(hidden)]
 pub type Offset = Limit;
 
-impl<ST, S, F, W, O, L, Of, G> OffsetDsl for SelectStatement<ST, S, F, W, O, L, Of, G> where
-    SelectStatement<ST, S, F, W, O, L, OffsetClause<Offset>, G>: Query<SqlType=ST>,
+impl<ST, S, F, D, W, O, L, Of, G> OffsetDsl
+    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
+        SelectStatement<ST, S, F, D, W, O, L, OffsetClause<Offset>, G>: Query<SqlType=ST>,
 {
-    type Output = SelectStatement<ST, S, F, W, O, L, OffsetClause<Offset>, G>;
+    type Output = SelectStatement<ST, S, F, D, W, O, L, OffsetClause<Offset>, G>;
 
     fn offset(self, offset: i64) -> Self::Output {
         let offset_clause = OffsetClause(AsExpression::<types::BigInt>::as_expression(offset));
-        SelectStatement::new(self.select, self.from, self.where_clause,
-            self.order, self.limit, offset_clause, self.group_by)
+        SelectStatement::new(
+            self.select,
+            self.from,
+            self.distinct,
+            self.where_clause,
+            self.order,
+            self.limit,
+            offset_clause,
+            self.group_by,
+        )
     }
 }
 
-impl<'a, ST, S, F, W, O, L, Of, G, Expr> WithDsl<'a, Expr>
-for SelectStatement<ST, S, F, W, O, L, Of, G> where
-    SelectStatement<ST, S, WithQuerySource<'a, F, Expr>, W, O, L, Of, G>: Query,
+impl<'a, ST, S, F, D, W, O, L, Of, G, Expr> WithDsl<'a, Expr>
+    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
+        SelectStatement<ST, S, WithQuerySource<'a, F, Expr>, D, W, O, L, Of, G>: Query,
 {
-    type Output = SelectStatement<ST, S, WithQuerySource<'a, F, Expr>, W, O, L, Of, G>;
+    type Output = SelectStatement<ST, S, WithQuerySource<'a, F, Expr>, D, W, O, L, Of, G>;
 
     fn with(self, expr: Aliased<'a, Expr>) -> Self::Output {
         let source = WithQuerySource::new(self.from, expr);
-        SelectStatement::new(self.select, source, self.where_clause,
-            self.order, self.limit, self.offset, self.group_by)
+        SelectStatement::new(
+            self.select,
+            source,
+            self.distinct,
+            self.where_clause,
+            self.order,
+            self.limit,
+            self.offset,
+            self.group_by,
+        )
     }
 }
 
-impl<ST, S, F, W, O, L, Of, G, Expr> GroupByDsl<Expr>
-for SelectStatement<ST, S, F, W, O, L, Of, G> where
-    SelectStatement<ST, S, F, W, O, L, Of, GroupByClause<Expr>>: Query,
-    Expr: Expression,
+impl<ST, S, F, D, W, O, L, Of, G, Expr> GroupByDsl<Expr>
+    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
+        SelectStatement<ST, S, F, D, W, O, L, Of, GroupByClause<Expr>>: Query,
+        Expr: Expression,
 {
-    type Output = SelectStatement<ST, S, F, W, O, L, Of, GroupByClause<Expr>>;
+    type Output = SelectStatement<ST, S, F, D, W, O, L, Of, GroupByClause<Expr>>;
 
     fn group_by(self, expr: Expr) -> Self::Output {
         let group_by = GroupByClause(expr);
-        SelectStatement::new(self.select, self.from, self.where_clause,
-            self.order, self.limit, self.offset, group_by)
+        SelectStatement::new(
+            self.select,
+            self.from,
+            self.distinct,
+            self.where_clause,
+            self.order,
+            self.limit,
+            self.offset,
+            group_by,
+        )
     }
 }
 
-impl<ST, S, F, W, O, L, Of, G, DB> InternalBoxedDsl<DB>
-for SelectStatement<ST, S, F, W, O, L, Of, G> where
-    DB: Backend,
-    S: QueryFragment<DB> + 'static,
-    W: Into<Option<Box<QueryFragment<DB>>>>,
-    O: QueryFragment<DB> + 'static,
-    L: QueryFragment<DB> + 'static,
-    Of: QueryFragment<DB> + 'static,
+impl<ST, S, F, D, W, O, L, Of, G, DB> InternalBoxedDsl<DB>
+    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
+        DB: Backend,
+        S: QueryFragment<DB> + 'static,
+        D: QueryFragment<DB> + 'static,
+        W: Into<Option<Box<QueryFragment<DB>>>>,
+        O: QueryFragment<DB> + 'static,
+        L: QueryFragment<DB> + 'static,
+        Of: QueryFragment<DB> + 'static,
 {
     type Output = BoxedSelectStatement<ST, F, DB>;
 
@@ -125,6 +204,7 @@ for SelectStatement<ST, S, F, W, O, L, Of, G> where
         BoxedSelectStatement::new(
             Box::new(self.select),
             self.from,
+            Box::new(self.distinct),
             self.where_clause.into(),
             Box::new(self.order),
             Box::new(self.limit),

--- a/diesel/src/query_dsl/distinct_dsl.rs
+++ b/diesel/src/query_dsl/distinct_dsl.rs
@@ -1,0 +1,48 @@
+use query_builder::AsQuery;
+use query_source::QuerySource;
+
+/// Adds the `DISTINCT` keyword to a query.
+///
+/// # Example
+///
+/// ```rust
+///
+/// # #[macro_use] extern crate diesel;
+/// # include!("src/doctest_setup.rs");
+/// #
+/// # table! {
+/// #     users {
+/// #         id -> Integer,
+/// #         name -> VarChar,
+/// #     }
+/// # }
+/// #
+/// # fn main() {
+/// #     use self::users::dsl::*;
+/// #     let connection = establish_connection();
+/// #     connection.execute("DELETE FROM users").unwrap();
+/// connection.execute("INSERT INTO users (name) VALUES ('Sean'), ('Sean'), ('Sean')")
+///     .unwrap();
+/// let names = users.select(name).load(&connection);
+/// let distinct_names = users.select(name).distinct().load(&connection);
+///
+/// let sean = String::from("Sean");
+/// assert_eq!(Ok(vec![sean.clone(), sean.clone(), sean.clone()]), names);
+/// assert_eq!(Ok(vec![sean.clone()]), distinct_names);
+/// # }
+/// ```
+pub trait DistinctDsl {
+    type Output;
+    fn distinct(self) -> Self::Output;
+}
+
+impl<T> DistinctDsl for T where
+    T: AsQuery + QuerySource,
+    T::Query: DistinctDsl,
+{
+    type Output = <T::Query as DistinctDsl>::Output;
+
+    fn distinct(self) -> Self::Output {
+        self.as_query().distinct()
+    }
+}

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -2,6 +2,7 @@ mod belonging_to_dsl;
 #[doc(hidden)]
 pub mod boxed_dsl;
 mod count_dsl;
+mod distinct_dsl;
 mod group_by_dsl;
 #[doc(hidden)]
 pub mod limit_dsl;
@@ -19,6 +20,7 @@ mod with_dsl;
 pub use self::belonging_to_dsl::BelongingToDsl;
 pub use self::boxed_dsl::BoxedDsl;
 pub use self::count_dsl::CountDsl;
+pub use self::distinct_dsl::DistinctDsl;
 pub use self::filter_dsl::{FilterDsl, FindDsl};
 #[doc(hidden)]
 pub use self::group_by_dsl::GroupByDsl;

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -51,7 +51,7 @@ select_column_workaround!(comments -> users (id, post_id, text));
 
 join_through!(users -> posts -> comments);
 
-#[derive(Debug, PartialEq, Eq, Queryable)]
+#[derive(Debug, PartialEq, Eq, Queryable, Clone)]
 #[insertable_into(users)]
 #[changeset_for(users)]
 pub struct NewUser {


### PR DESCRIPTION
A few things to note about the implementation. I've opted for 2 unit
structs instead of something like an enum or boolean so that the code
gets inlined via monomorphisation instead of containing a branch (e.g.
if you don't use distinct, it's free). As always, it's enforced that our
query builder doesn't do "real work" by
https://github.com/sgrif/diesel/blob/c8127d408f759faa056503014cd00e92479215e0/diesel_tests/tests/perf_details.rs#L8-L13

This ended up churning a lot of `select_dsl`. I've reformatted the code
surrounding what was touched to reduce churn in the future.

This doesn't yet add support for `DISTINCT ON(expr)`, as that is a PG
specific feature and can be added as a separate PR.

An alternative API for this would be something like
`users.select(distinct(name))`. I actually think I might prefer that
API, but actually enforcing correctness with it (making sure `distinct`
can only be passed to `select` and not something like `filter` --
disallowing things like `max(distinct(id))`, etc) would be pretty much
impossible.

Fixes #253.