### PR TITLE
Implement `FilterDsl` for BoxedSelectStatement

### DIFF
--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -114,7 +114,7 @@ impl<ST, S, F, W, O, L, Of, G, DB> InternalBoxedDsl<DB>
 for SelectStatement<ST, S, F, W, O, L, Of, G> where
     DB: Backend,
     S: QueryFragment<DB> + 'static,
-    W: QueryFragment<DB> + 'static,
+    W: Into<Option<Box<QueryFragment<DB>>>>,
     O: QueryFragment<DB> + 'static,
     L: QueryFragment<DB> + 'static,
     Of: QueryFragment<DB> + 'static,
@@ -125,7 +125,7 @@ for SelectStatement<ST, S, F, W, O, L, Of, G> where
         BoxedSelectStatement::new(
             Box::new(self.select),
             self.from,
-            Box::new(self.where_clause),
+            self.where_clause.into(),
             Box::new(self.order),
             Box::new(self.limit),
             Box::new(self.offset),

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -30,6 +30,12 @@ impl<Predicate> WhereAnd<Predicate> for NoWhereClause where
     }
 }
 
+impl<DB: Backend> Into<Option<Box<QueryFragment<DB>>>> for NoWhereClause {
+    fn into(self) -> Option<Box<QueryFragment<DB>>> {
+        None
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct WhereClause<Expr>(Expr);
 
@@ -51,5 +57,14 @@ impl<Expr, Predicate> WhereAnd<Predicate> for WhereClause<Expr> where
 
     fn and(self, predicate: Predicate) -> Self::Output {
         WhereClause(self.0.and(predicate))
+    }
+}
+
+impl<DB, Predicate> Into<Option<Box<QueryFragment<DB>>>> for WhereClause<Predicate> where
+    DB: Backend,
+    Predicate: QueryFragment<DB> + 'static,
+{
+    fn into(self) -> Option<Box<QueryFragment<DB>>> {
+        Some(Box::new(self.0))
     }
 }

--- a/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_filter.rs
+++ b/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_filter.rs
@@ -1,0 +1,24 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+use diesel::pg::Pg;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        title -> VarChar,
+    }
+}
+
+fn main() {
+    users::table.into_boxed::<Pg>().filter(posts::title.eq("Hello"));
+    //~^ ERROR SelectableExpression
+}

--- a/diesel_tests/tests/boxed_queries.rs
+++ b/diesel_tests/tests/boxed_queries.rs
@@ -67,3 +67,16 @@ fn boxed_queries_implement_select_dsl() {
         .load::<String>(&connection);
     assert_eq!(Ok(vec!["Sean".into(), "Tess".into()]), data);
 }
+
+#[test]
+fn boxed_queries_implement_filter_dsl() {
+    let connection = connection_with_sean_and_tess_in_users_table();
+    insert(&NewUser::new("Shane", None)).into(users::table)
+        .execute(&connection).unwrap();
+    let data = users::table.into_boxed()
+        .select(users::name)
+        .filter(users::name.ne("Sean"))
+        .filter(users::name.like("S%"))
+        .load(&connection);
+    assert_eq!(Ok(vec![String::from("Shane")]), data);
+}


### PR DESCRIPTION
We had to switch the type of the where clause to an option, and handle
whether or not to put `WHERE` in the query explicitly to handle the
`AND` case when filter is called twice. I had tried to instead box up
`WhereAnd`, but ultimately if you try and write
`impl WhereAnd<Box<QueryFragment<DB>>>`, the output type ends up being
infinitely recursive, as the output type would be a `Box<WhereAnd>`, and
would need the output type specified, etc.