### PR TITLE
Remove `no select` from `table!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `#[insertable_into]` can now be used with structs that have lifetimes with
   names other than `'a'`.
 
+### Removed
+
+* Removed the `no select` option for the `table!` macro. This was a niche
+  feature that didn't fit with Diesel's philosophies. You can write a function
+  that calls `select` for you if you need this functionality.
+
 ## [0.5.4] 2016-03-23
 
 * Updated `diesel_codegen` to allow syntex versions up to 0.30.0.

--- a/diesel/src/macros.rs
+++ b/diesel/src/macros.rs
@@ -74,7 +74,8 @@ macro_rules! column {
 /// # fn main() {}
 /// ```
 ///
-/// More complex usage:
+/// You may also specify a primary key if it's called something other than `id`.
+/// Tables with no primary key, or composite primary keys aren't yet supported.
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
@@ -83,8 +84,6 @@ macro_rules! column {
 ///         non_standard_primary_key -> Integer,
 ///         name -> VarChar,
 ///         favorite_color -> Nullable<VarChar>,
-///     } no select {
-///         complex_index_column -> Text,
 ///     }
 /// }
 /// # fn main() {}
@@ -103,8 +102,7 @@ macro_rules! column {
 /// all_columns
 /// -----------
 ///
-/// A constant will be assigned called `all_columns`, which will be a tuple of
-/// all the columns that aren't in the "no select" group. This is what will be
+/// A constant will be assigned called `all_columns`. This is what will be
 /// selected if you don't otherwise specify a select clause. It's type will be
 /// `table::AllColumns`. You can also get this value from the
 /// `Table::all_columns` function.
@@ -136,42 +134,12 @@ macro_rules! table {
             $($column_name:ident -> $Type:ty,)+
         }
     ) => {
-        table! {
-            $name ($pk) {
-                $($column_name -> $Type,)+
-            } no select {}
-        }
-    };
-    (
-        $name:ident {
-            $($column_name:ident -> $Type:ty,)+
-        } no select {
-            $($no_select_column_name:ident -> $no_select_type:ty,)*
-        }
-    ) => {
-        table! {
-            $name (id) {
-                $($column_name -> $Type,)+
-            } no select {
-                $($no_select_column_name -> $no_select_type,)*
-            }
-        }
-    };
-    (
-        $name:ident ($pk:ident) {
-            $($column_name:ident -> $Type:ty,)+
-        } no select {
-            $($no_select_column_name:ident -> $no_select_type:ty,)*
-        }
-    ) => {
         table_body! {
             $name ($pk) {
                 $($column_name -> $Type,)+
-            } no select {
-                $($no_select_column_name -> $no_select_type,)*
             }
         }
-    }
+    };
 }
 
 #[macro_export]
@@ -180,8 +148,6 @@ macro_rules! table_body {
     (
         $name:ident ($pk:ident) {
             $($column_name:ident -> $Type:ty,)+
-        } no select {
-            $($no_select_column_name:ident -> $no_select_type:ty,)*
         }
     ) => {
         pub mod $name {
@@ -275,7 +241,6 @@ macro_rules! table_body {
                 impl SelectableExpression<table> for star {}
 
                 $(column!(table, $column_name -> $Type);)+
-                $(column!(table, $no_select_column_name -> $no_select_type);)*
             }
         }
     }


### PR DESCRIPTION
This was something that I added to support crates.io, as their crates
table has a column that's only used for querying but not ever actually
selected. Ultimately this just doesn't fit with Diesel's overall
philosophy. It was poorly documented and untested. Just set up an `all`
function that calls `select` if you need this.