### PR TITLE
Allow users to opt into usage of specialization

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -2,6 +2,7 @@
 //! interactions. [A getting started guide](https://github.com/sgrif/diesel#getting-started) can be
 //! found in the README.
 #![deny(warnings)]
+#![cfg_attr(feature = "unstable", feature(specialization))]
 pub mod backend;
 pub mod connection;
 #[macro_use]

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -7,8 +7,7 @@ use std::io::Write;
 use backend::Debug;
 use pg::{Pg, PgTypeMetadata};
 use query_source::Queryable;
-use row::Row;
-use types::{HasSqlType, FromSql, FromSqlRow, ToSql, Array, IsNull, NotNull};
+use types::{HasSqlType, FromSql, ToSql, Array, IsNull, NotNull};
 
 impl<T> HasSqlType<Array<T>> for Pg where
     Pg: HasSqlType<T>,
@@ -63,11 +62,14 @@ impl<T, ST> FromSql<Array<ST>, Pg> for Vec<T> where
     }
 }
 
+#[cfg(not(feature = "unstable"))]
+use types::FromSqlRow;
+#[cfg(not(feature = "unstable"))]
 impl<T, ST> FromSqlRow<Array<ST>, Pg> for Vec<T> where
     Pg: HasSqlType<ST>,
     Vec<T>: FromSql<Array<ST>, Pg>,
 {
-    fn build_from_row<R: Row<Pg>>(row: &mut R) -> Result<Self, Box<Error+Send+Sync>> {
+    fn build_from_row<R: ::row::Row<Pg>>(row: &mut R) -> Result<Self, Box<Error+Send+Sync>> {
         FromSql::<Array<ST>, Pg>::from_sql(row.take())
     }
 }

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -58,7 +58,7 @@ macro_rules! expression_impls {
 
 macro_rules! queryable_impls {
     ($($Source:ident -> $Target:ty),+,) => {$(
-        //FIXME: This can be made generic w/ specialization by making FromSql imply FromSqlRow
+        #[cfg(not(feature = "unstable"))]
         impl<DB> $crate::types::FromSqlRow<types::$Source, DB> for $Target where
             DB: $crate::backend::Backend + $crate::types::HasSqlType<types::$Source>,
             $Target: $crate::types::FromSql<types::$Source, DB>,
@@ -68,7 +68,7 @@ macro_rules! queryable_impls {
             }
         }
 
-        //FIXME: This can be made generic w/ specialization by making FromSql imply FromSqlRow
+        #[cfg(not(feature = "unstable"))]
         impl<DB> $crate::types::FromSqlRow<$crate::types::Nullable<types::$Source>, DB> for Option<$Target> where
             DB: $crate::backend::Backend + $crate::types::HasSqlType<types::$Source>,
             Option<$Target>: $crate::types::FromSql<$crate::types::Nullable<types::$Source>, DB>,

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -94,6 +94,11 @@ pub trait FromSqlRow<A, DB: Backend + HasSqlType<A>>: Sized {
     fn build_from_row<T: Row<DB>>(row: &mut T) -> Result<Self, Box<Error+Send+Sync>>;
 }
 
+// FIXME: This can be inlined once 1.9 is stable. The parser can't handle the `default` keyword on
+// stable prior to that version
+#[cfg(feature = "unstable")]
+include!("specialization_impls.rs");
+
 #[derive(Debug, PartialEq, Eq)]
 /// Tiny enum to make the return type of `ToSql` more descriptive
 pub enum IsNull {

--- a/diesel/src/types/specialization_impls.rs
+++ b/diesel/src/types/specialization_impls.rs
@@ -1,0 +1,8 @@
+impl<T, ST, DB> FromSqlRow<ST, DB> for T where
+    T: FromSql<ST, DB>,
+    DB: Backend + HasSqlType<ST>,
+{
+    default fn build_from_row<R: Row<DB>>(row: &mut R) -> Result<Self, Box<Error+Send+Sync>> {
+        FromSql::<ST, DB>::from_sql(row.take())
+    }
+}

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -377,6 +377,7 @@ fn third_party_crates_can_add_new_types() {
         }
     }
 
+    #[cfg(not(feature = "unstable"))]
     impl FromSqlRow<MyInt, Pg> for i32 {
         fn build_from_row<R: ::diesel::row::Row<Pg>>(row: &mut R) -> Result<Self, Box<Error+Send+Sync>> {
             FromSql::<MyInt, Pg>::from_sql(row.take())


### PR DESCRIPTION
This is a change that I want to make eventually just to clean up our
code. However, there is a concrete case that can't wait for
specialization to land. There is not way for a user to implement
`FromSqlRow` for a nullable field of a custom type (e.g. a PG enum).

Using diesel with the `unstable` feature now uses specialization, which
we can start using elsewhere. We unfortunately still won't be able to
clean up the code base until specialization is stable, but we can at
least start to look at what the code *might* look like.