### PR TITLE
Implement `Send` for `SqliteConnection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * The `DISTINCT` keyword can now be added to queries via the `distinct()`
   method.
 
+* `SqliteConnection` now implements `Send`
+
 ### Changed
 
 * `diesel::result::Error` now implements `Send` and `Sync`. This required a

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -29,6 +29,11 @@ pub struct SqliteConnection {
     transaction_depth: Cell<i32>,
 }
 
+// This relies on the invariant that RawConnection or Statement are never
+// leaked. If a reference to one of those was held on a different thread, this
+// would not be thread safe.
+unsafe impl Send for SqliteConnection {}
+
 impl SimpleConnection for SqliteConnection {
     fn batch_execute(&self, query: &str) -> QueryResult<()> {
         self.raw_connection.exec(query)


### PR DESCRIPTION
After spending some time poking at it, I can't find any reason this
wouldn't be safe. There's a legitimate use case for this where you want
to share a connection to an in memory database (wrapped in a mutex of
course)

Fixes #228