### PR TITLE
Properly generate a single element tuple for 1 column tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `#[insertable_into]` can now be used with structs that have lifetimes with
   names other than `'a'`.
 
+* Tables with a single column now properly return a single element tuple. E.g.
+  if the column was of type integer, then `users::all_columns` is now `(id,)`
+  and not `id`.
+
 ### Removed
 
 * Removed the `no select` option for the `table!` macro. This was a niche

--- a/diesel/src/macros.rs
+++ b/diesel/src/macros.rs
@@ -182,7 +182,7 @@ macro_rules! table_body {
             }
 
             #[allow(non_upper_case_globals, dead_code)]
-            pub const all_columns: ($($column_name),+) = ($($column_name),+);
+            pub const all_columns: ($($column_name,)+) = ($($column_name,)+);
 
             #[allow(non_camel_case_types)]
             #[derive(Clone, Copy)]
@@ -195,7 +195,7 @@ macro_rules! table_body {
                 }
             }
 
-            pub type SqlType = ($($Type),+);
+            pub type SqlType = ($($Type,)+);
 
             pub type BoxedQuery<'a, DB, ST = SqlType> = BoxedSelectStatement<'a, ST, table, DB>;
 
@@ -209,7 +209,7 @@ macro_rules! table_body {
 
             impl AsQuery for table {
                 type SqlType = SqlType;
-                type Query = SelectStatement<SqlType, ($($column_name),+), Self>;
+                type Query = SelectStatement<SqlType, ($($column_name,)+), Self>;
 
                 fn as_query(self) -> Self::Query {
                     SelectStatement::simple(all_columns, self)
@@ -218,7 +218,7 @@ macro_rules! table_body {
 
             impl Table for table {
                 type PrimaryKey = columns::$pk;
-                type AllColumns = ($($column_name),+);
+                type AllColumns = ($($column_name,)+);
 
                 fn name() -> &'static str {
                     stringify!($name)
@@ -229,7 +229,7 @@ macro_rules! table_body {
                 }
 
                 fn all_columns() -> Self::AllColumns {
-                    ($($column_name),+)
+                    ($($column_name,)+)
                 }
             }
 

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -71,7 +71,7 @@ macro_rules! tuple_impls {
             }
 
             impl<$($T: Expression + NonAggregate),+> Expression for ($($T,)+) {
-                type SqlType = ($(<$T as Expression>::SqlType),+);
+                type SqlType = ($(<$T as Expression>::SqlType,)+);
             }
 
             impl<$($T: QueryFragment<DB>),+, DB: Backend> QueryFragment<DB> for ($($T,)+) {

--- a/diesel_tests/tests/find.rs
+++ b/diesel_tests/tests/find.rs
@@ -31,7 +31,7 @@ fn find_with_non_serial_pk() {
     connection.execute("INSERT INTO users_with_name_pk (name) VALUES ('Sean'), ('Tess')")
         .unwrap();
 
-    assert_eq!(Ok("Sean".to_string()), users.find("Sean").first(&connection));
-    assert_eq!(Ok("Tess".to_string()), users.find("Tess".to_string()).first(&connection));
-    assert_eq!(Ok(None::<String>), users.find("Wibble").first(&connection).optional());
+    assert_eq!(Ok(("Sean".to_string(),)), users.find("Sean").first(&connection));
+    assert_eq!(Ok(("Tess".to_string(),)), users.find("Tess".to_string()).first(&connection));
+    assert_eq!(Ok(None::<(String,)>), users.find("Wibble").first(&connection).optional());
 }


### PR DESCRIPTION
Our code was generating `(id)` and not `(id,)`. Without the trailing
comma, the parenthesis are meaningless. This meant that you couldn't
actually load the query into a struct without manually selecting the
tuple.

While this fixes the bug, I think it probably also makes sense for us to
have a `FromSqlRow` and `Queryable` impl for the non-tuple type into a
single element tuple/struct.

Fixes #261