### PR TITLE
Change bind collection to be a 2-pass process

### DIFF
--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -1,4 +1,4 @@
-use query_builder::QueryBuilder;
+use query_builder::{QueryBuilder, BindCollector};
 use query_builder::debug::DebugQueryBuilder;
 use types::{self, HasSqlType};
 
@@ -17,6 +17,7 @@ pub trait Backend where
     Self: HasSqlType<types::Timestamp>,
 {
     type QueryBuilder: QueryBuilder<Self>;
+    type BindCollector: BindCollector<Self>;
     type RawValue: ?Sized;
 }
 
@@ -31,7 +32,15 @@ pub struct Debug;
 
 impl Backend for Debug {
     type QueryBuilder = DebugQueryBuilder;
+    type BindCollector = ();
     type RawValue = ();
+}
+
+impl BindCollector<Debug> for () {
+    fn push_bound_value<T>(&mut self, _binds: Option<Vec<u8>>) where
+        Debug: HasSqlType<T>,
+    {
+    }
 }
 
 impl TypeMetadata for Debug {

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -1,10 +1,10 @@
 extern crate dotenv;
 
-use diesel::prelude::*;
 use diesel::backend;
-use self::dotenv::dotenv;
-use diesel::query_builder::{QueryBuilder, BuildQueryResult};
 use diesel::persistable::{InsertValues};
+use diesel::prelude::*;
+use diesel::query_builder::{QueryBuilder, BuildQueryResult};
+use self::dotenv::dotenv;
 
 #[cfg(feature = "postgres")]
 type DB = diesel::pg::Pg;
@@ -75,6 +75,10 @@ impl<DB> InsertValues<DB> for NewUserValues where
 
     fn values_clause(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_sql(&format!("('{}')", self.name));
+        Ok(())
+    }
+
+    fn values_bind_params(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/expression/aliased.rs
+++ b/diesel/src/expression/aliased.rs
@@ -3,6 +3,7 @@ use expression::{Expression, NonAggregate, SelectableExpression};
 use query_builder::*;
 use query_builder::nodes::{Identifier, InfixNode};
 use query_source::*;
+use result::QueryResult;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Aliased<'a, Expr> {
@@ -33,6 +34,10 @@ impl<'a, T, DB> QueryFragment<DB> for Aliased<'a, T> where
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_identifier(&self.alias)
+    }
+
+    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+        Ok(())
     }
 }
 

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -1,5 +1,6 @@
 use backend::Backend;
 use query_builder::*;
+use result::QueryResult;
 use super::{Expression, SelectableExpression};
 use types::BigInt;
 
@@ -62,6 +63,11 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Count<T> {
         out.push_sql(")");
         Ok(())
     }
+
+    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+        try!(self.target.collect_binds(out));
+        Ok(())
+    }
 }
 
 impl<T: Expression, QS> SelectableExpression<QS> for Count<T> {
@@ -78,6 +84,10 @@ impl Expression for CountStar {
 impl<DB: Backend> QueryFragment<DB> for CountStar {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_sql("COUNT(*)");
+        Ok(())
+    }
+
+    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -1,6 +1,7 @@
 use backend::Backend;
 use expression::{Expression, SelectableExpression};
 use query_builder::*;
+use result::QueryResult;
 use types::{Foldable, HasSqlType};
 
 macro_rules! fold_function {
@@ -35,6 +36,11 @@ macro_rules! fold_function {
                 out.push_sql(concat!($operator, "("));
                 try!(self.target.to_sql(out));
                 out.push_sql(")");
+                Ok(())
+            }
+
+            fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+                try!(self.target.collect_binds(out));
                 Ok(())
             }
         }

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -1,6 +1,7 @@
 use backend::Backend;
 use expression::{Expression, SelectableExpression};
 use query_builder::*;
+use result::QueryResult;
 use types::{SqlOrd, HasSqlType};
 
 macro_rules! ord_function {
@@ -32,6 +33,11 @@ macro_rules! ord_function {
                 out.push_sql(concat!($operator, "("));
                 try!(self.target.to_sql(out));
                 out.push_sql(")");
+                Ok(())
+            }
+
+            fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+                try!(self.target.collect_binds(out));
                 Ok(())
             }
         }

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -1,6 +1,7 @@
 use backend::Backend;
 use expression::{Expression, SelectableExpression, NonAggregate};
 use query_builder::*;
+use result::QueryResult;
 use types::*;
 
 /// Represents the SQL CURRENT_TIMESTAMP constant. This is equivalent to the
@@ -21,6 +22,10 @@ impl NonAggregate for now {
 impl<DB: Backend> QueryFragment<DB> for now {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_sql("CURRENT_TIMESTAMP");
+        Ok(())
+    }
+
+    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -38,15 +38,20 @@ macro_rules! sql_function_body {
             DB: $crate::backend::Backend,
             for <'a> ($(&'a $arg_name),*): $crate::query_builder::QueryFragment<DB>,
         {
-            fn to_sql(&self, out: &mut DB::QueryBuilder)
-                -> $crate::query_builder::BuildQueryResult {
-                    use $crate::query_builder::QueryBuilder;
-                    out.push_sql(concat!(stringify!($fn_name), "("));
-                    try!($crate::query_builder::QueryFragment::to_sql(
+            fn to_sql(&self, out: &mut DB::QueryBuilder) -> $crate::query_builder::BuildQueryResult {
+                use $crate::query_builder::QueryBuilder;
+                out.push_sql(concat!(stringify!($fn_name), "("));
+                try!($crate::query_builder::QueryFragment::to_sql(
                         &($(&self.$arg_name),*), out));
-                    out.push_sql(")");
-                    Ok(())
-                }
+                out.push_sql(")");
+                Ok(())
+            }
+
+            fn collect_binds(&self, out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
+                try!($crate::query_builder::QueryFragment::collect_binds(
+                        &($(&self.$arg_name),*), out));
+                Ok(())
+            }
         }
 
         #[allow(non_camel_case_types)]
@@ -137,11 +142,13 @@ macro_rules! no_arg_sql_function_body {
         impl<DB> $crate::query_builder::QueryFragment<DB> for $type_name where
             DB: $crate::backend::Backend + $($constraint)::+,
         {
-            fn to_sql(&self, out: &mut DB::QueryBuilder)
-                -> $crate::query_builder::BuildQueryResult
-            {
+            fn to_sql(&self, out: &mut DB::QueryBuilder) -> $crate::query_builder::BuildQueryResult {
                 use $crate::query_builder::QueryBuilder;
                 out.push_sql(concat!(stringify!($type_name), "()"));
+                Ok(())
+            }
+
+            fn collect_binds(&self, _out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
                 Ok(())
             }
         }
@@ -153,11 +160,13 @@ macro_rules! no_arg_sql_function_body {
         impl<DB> $crate::query_builder::QueryFragment<DB> for $type_name where
             DB: $crate::backend::Backend,
         {
-            fn to_sql(&self, out: &mut DB::QueryBuilder)
-                -> $crate::query_builder::BuildQueryResult
-            {
+            fn to_sql(&self, out: &mut DB::QueryBuilder) -> $crate::query_builder::BuildQueryResult {
                 use $crate::query_builder::QueryBuilder;
                 out.push_sql(concat!(stringify!($type_name), "()"));
+                Ok(())
+            }
+
+            fn collect_binds(&self, _out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
                 Ok(())
             }
         }

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -1,6 +1,7 @@
 use backend::Backend;
 use expression::{Expression, SelectableExpression, NonAggregate};
 use query_builder::*;
+use result::QueryResult;
 
 pub struct Grouped<T>(pub T);
 
@@ -13,6 +14,11 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Grouped<T> {
         out.push_sql("(");
         try!(self.0.to_sql(out));
         out.push_sql(")");
+        Ok(())
+    }
+
+    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+        try!(self.0.collect_binds(out));
         Ok(())
     }
 }

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -1,6 +1,7 @@
 use backend::Backend;
 use expression::{Expression, SelectableExpression, NonAggregate};
 use query_builder::*;
+use result::QueryResult;
 use types::IntoNullable;
 
 pub struct Nullable<T>(T);
@@ -24,6 +25,10 @@ impl<T, DB> QueryFragment<DB> for Nullable<T> where
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         self.0.to_sql(out)
+    }
+
+    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+        self.0.collect_binds(out)
     }
 }
 

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -1,6 +1,7 @@
 use backend::Backend;
 use expression::{Expression, SelectableExpression, NonAggregate};
 use query_builder::*;
+use result::QueryResult;
 use types;
 
 macro_rules! numeric_operation {
@@ -36,6 +37,12 @@ macro_rules! numeric_operation {
                 try!(self.lhs.to_sql(out));
                 out.push_sql($op);
                 self.rhs.to_sql(out)
+            }
+
+            fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+                try!(self.lhs.collect_binds(out));
+                try!(self.rhs.collect_binds(out));
+                Ok(())
             }
         }
 

--- a/diesel/src/expression/predicates.rs
+++ b/diesel/src/expression/predicates.rs
@@ -52,6 +52,12 @@ macro_rules! global_infix_predicate_to_sql {
                 out.push_sql($operator);
                 self.right.to_sql(out)
             }
+
+            fn collect_binds(&self, out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
+                try!(self.left.collect_binds(out));
+                try!(self.right.collect_binds(out));
+                Ok(())
+            }
         }
     }
 }
@@ -72,6 +78,14 @@ macro_rules! backend_specific_infix_predicate_to_sql {
                 out.push_sql($operator);
                 self.right.to_sql(out)
             }
+
+            fn collect_binds(&self, out: &mut <$backend as $crate::backend::Backend>::BindCollector)
+                -> $crate::result::QueryResult<()>
+            {
+                try!(self.left.collect_binds(out));
+                try!(self.right.collect_binds(out));
+                Ok(())
+            }
         }
 
         impl<T, U> $crate::query_builder::QueryFragment<$crate::backend::Debug>
@@ -87,6 +101,15 @@ macro_rules! backend_specific_infix_predicate_to_sql {
                 try!(self.left.to_sql(out));
                 out.push_sql($operator);
                 self.right.to_sql(out)
+            }
+
+            fn collect_binds(
+                &self,
+                out: &mut <$crate::backend::Debug as $crate::backend::Backend>::BindCollector,
+            ) -> $crate::result::QueryResult<()> {
+                try!(self.left.collect_binds(out));
+                try!(self.right.collect_binds(out));
+                Ok(())
             }
         }
     }
@@ -158,6 +181,11 @@ macro_rules! postfix_predicate_body {
                 out.push_sql($operator);
                 Ok(())
             }
+
+            fn collect_binds(&self, out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
+                try!(self.expr.collect_binds(out));
+                Ok(())
+            }
         }
 
         impl<T, QS> $crate::expression::SelectableExpression<QS> for $name<T> where
@@ -209,6 +237,7 @@ postfix_expression!(Desc, " DESC", ());
 use backend::Backend;
 use query_source::Column;
 use query_builder::*;
+use result::QueryResult;
 use super::SelectableExpression;
 
 impl<T, U, DB> Changeset<DB> for Eq<T, U> where
@@ -224,6 +253,10 @@ impl<T, U, DB> Changeset<DB> for Eq<T, U> where
         try!(out.push_identifier(T::name()));
         out.push_sql(" = ");
         QueryFragment::to_sql(&self.right, out)
+    }
+
+    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+        QueryFragment::collect_binds(&self.right, out)
     }
 }
 

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -1,5 +1,6 @@
 use backend::Backend;
 use query_builder::*;
+use result::QueryResult;
 use std::marker::PhantomData;
 use super::{Expression, SelectableExpression, NonAggregate};
 use types::HasSqlType;
@@ -31,6 +32,10 @@ impl<ST, DB> QueryFragment<DB> for SqlLiteral<ST> where
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_sql(&self.sql);
+        Ok(())
+    }
+
+    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/macros.rs
+++ b/diesel/src/macros.rs
@@ -25,6 +25,10 @@ macro_rules! column {
                 out.push_sql(".");
                 out.push_identifier(stringify!($column_name))
             }
+
+            fn collect_binds(&self, _out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
+                Ok(())
+            }
         }
 
         impl $crate::expression::SelectableExpression<$($table)::*> for $column_name {}
@@ -238,6 +242,7 @@ macro_rules! table_body {
                 use $crate::{Table, Column, Expression, SelectableExpression};
                 use $crate::backend::Backend;
                 use $crate::query_builder::{QueryBuilder, BuildQueryResult, QueryFragment};
+                use $crate::result::QueryResult;
                 use $crate::types::*;
 
                 #[allow(non_camel_case_types, dead_code)]
@@ -252,6 +257,10 @@ macro_rules! table_body {
                     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
                         try!(out.push_identifier(table::name()));
                         out.push_sql(".*");
+                        Ok(())
+                    }
+
+                    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
                         Ok(())
                     }
                 }

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -1,4 +1,5 @@
 use backend::*;
+use query_builder::bind_collector::RawBytesBindCollector;
 use super::query_builder::PgQueryBuilder;
 
 pub struct Pg;
@@ -11,6 +12,7 @@ pub struct PgTypeMetadata {
 
 impl Backend for Pg {
     type QueryBuilder = PgQueryBuilder;
+    type BindCollector = RawBytesBindCollector<Pg>;
     type RawValue = [u8];
 }
 

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -5,6 +5,7 @@ use expression::{AsExpression, Expression, SelectableExpression, NonAggregate};
 use pg::{Pg, PgQueryBuilder};
 use query_builder::*;
 use query_builder::debug::DebugQueryBuilder;
+use result::QueryResult;
 use types::{Array, HasSqlType};
 
 /// Creates a PostgreSQL `ANY` expression.
@@ -75,6 +76,11 @@ impl<Expr, ST> QueryFragment<Pg> for Any<Expr, ST> where
         out.push_sql(")");
         Ok(())
     }
+
+    fn collect_binds(&self, out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+        try!(self.expr.collect_binds(out));
+        Ok(())
+    }
 }
 
 impl<Expr, ST> QueryFragment<Debug> for Any<Expr, ST> where
@@ -84,6 +90,11 @@ impl<Expr, ST> QueryFragment<Debug> for Any<Expr, ST> where
         out.push_sql("ANY(");
         try!(self.expr.to_sql(out));
         out.push_sql(")");
+        Ok(())
+    }
+
+    fn collect_binds(&self, out: &mut <Debug as Backend>::BindCollector) -> QueryResult<()> {
+        try!(self.expr.collect_binds(out));
         Ok(())
     }
 }

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -2,6 +2,7 @@ use backend::*;
 use expression::{Expression, SelectableExpression, NonAggregate};
 use pg::{Pg, PgQueryBuilder};
 use query_builder::*;
+use result::QueryResult;
 use types::{Timestamp, VarChar};
 
 pub struct AtTimeZone<Ts, Tz> {
@@ -40,6 +41,12 @@ impl<Ts, Tz> QueryFragment<Pg> for AtTimeZone<Ts, Tz> where
         out.push_sql(" AT TIME ZONE ");
         self.timezone.to_sql(out)
     }
+
+    fn collect_binds(&self, out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+        try!(self.timestamp.collect_binds(out));
+        try!(self.timezone.collect_binds(out));
+        Ok(())
+    }
 }
 
 impl<Ts, Tz> QueryFragment<Debug> for AtTimeZone<Ts, Tz> where
@@ -50,6 +57,12 @@ impl<Ts, Tz> QueryFragment<Debug> for AtTimeZone<Ts, Tz> where
         try!(self.timestamp.to_sql(out));
         out.push_sql(" AT TIME ZONE ");
         self.timezone.to_sql(out)
+    }
+
+    fn collect_binds(&self, out: &mut <Debug as Backend>::BindCollector) -> QueryResult<()> {
+        try!(self.timestamp.collect_binds(out));
+        try!(self.timezone.collect_binds(out));
+        Ok(())
     }
 }
 

--- a/diesel/src/pg/query_builder.rs
+++ b/diesel/src/pg/query_builder.rs
@@ -2,14 +2,11 @@ use std::rc::Rc;
 
 use super::backend::Pg;
 use super::connection::raw::RawConnection;
-use query_builder::{QueryBuilder, Binds, BuildQueryResult};
-use types::HasSqlType;
+use query_builder::{QueryBuilder, BuildQueryResult};
 
 pub struct PgQueryBuilder {
     conn: Rc<RawConnection>,
     pub sql: String,
-    pub binds: Binds,
-    pub bind_types: Vec<u32>,
     bind_idx: u32,
 }
 
@@ -18,8 +15,6 @@ impl PgQueryBuilder {
         PgQueryBuilder {
             conn: conn.clone(),
             sql: String::new(),
-            binds: Vec::new(),
-            bind_types: Vec::new(),
             bind_idx: 0,
         }
     }
@@ -35,13 +30,9 @@ impl QueryBuilder<Pg> for PgQueryBuilder {
         Ok(self.push_sql(&escaped_identifier))
     }
 
-    fn push_bound_value<T>(&mut self, bind: Option<Vec<u8>>) where
-        Pg: HasSqlType<T>,
-    {
+    fn push_bind_param(&mut self) {
         self.bind_idx += 1;
         let sql = format!("${}", self.bind_idx);
         self.push_sql(&sql);
-        self.binds.push(bind);
-        self.bind_types.push(Pg::metadata().oid);
     }
 }

--- a/diesel/src/query_builder/bind_collector.rs
+++ b/diesel/src/query_builder/bind_collector.rs
@@ -1,0 +1,25 @@
+use backend::{Backend, TypeMetadata};
+use types::HasSqlType;
+
+pub trait BindCollector<DB: Backend> {
+    fn push_bound_value<T>(&mut self, bind: Option<Vec<u8>>) where DB: HasSqlType<T>;
+}
+
+pub struct RawBytesBindCollector<DB: Backend + TypeMetadata> {
+    pub binds: Vec<(DB::TypeMetadata, Option<Vec<u8>>)>,
+}
+
+impl<DB: Backend + TypeMetadata> RawBytesBindCollector<DB> {
+    pub fn new() -> Self {
+        RawBytesBindCollector {
+            binds: Vec::new(),
+        }
+    }
+}
+
+impl<DB: Backend + TypeMetadata> BindCollector<DB> for RawBytesBindCollector<DB> {
+    fn push_bound_value<T>(&mut self, bind: Option<Vec<u8>>) where DB: HasSqlType<T> {
+        let metadata = <DB as HasSqlType<T>>::metadata();
+        self.binds.push((metadata, bind));
+    }
+}

--- a/diesel/src/query_builder/clause_macro.rs
+++ b/diesel/src/query_builder/clause_macro.rs
@@ -1,6 +1,7 @@
 macro_rules! simple_clause {
     ($no_clause:ident, $clause:ident, $sql:expr) => {
         use backend::Backend;
+        use result::QueryResult;
         use super::{QueryFragment, QueryBuilder, BuildQueryResult};
 
         #[derive(Debug, Clone, Copy)]
@@ -8,6 +9,10 @@ macro_rules! simple_clause {
 
         impl<DB: Backend> QueryFragment<DB> for $no_clause {
             fn to_sql(&self, _out: &mut DB::QueryBuilder) -> BuildQueryResult {
+                Ok(())
+            }
+
+            fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
                 Ok(())
             }
         }
@@ -22,6 +27,10 @@ macro_rules! simple_clause {
             fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
                 out.push_sql($sql);
                 self.0.to_sql(out)
+            }
+
+            fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+                self.0.collect_binds(out)
             }
         }
     }

--- a/diesel/src/query_builder/debug.rs
+++ b/diesel/src/query_builder/debug.rs
@@ -1,6 +1,5 @@
 use backend::Debug;
 use super::{QueryBuilder, BuildQueryResult};
-use types::HasSqlType;
 
 #[doc(hidden)]
 pub struct DebugQueryBuilder {
@@ -29,10 +28,7 @@ impl QueryBuilder<Debug> for DebugQueryBuilder {
         Ok(())
     }
 
-    #[allow(unused_variables)]
-    fn push_bound_value<T>(&mut self, bind: Option<Vec<u8>>) where
-        Debug: HasSqlType<T>,
-    {
+    fn push_bind_param(&mut self) {
         self.push_sql("?");
     }
 }

--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -1,5 +1,6 @@
 use backend::Backend;
 use query_builder::*;
+use result::QueryResult;
 
 pub struct DeleteStatement<T>(T);
 
@@ -22,6 +23,14 @@ impl<T, DB> QueryFragment<DB> for DeleteStatement<T> where
         if let Some(clause) = self.0.where_clause() {
             out.push_sql(" WHERE ");
             try!(clause.to_sql(out));
+        }
+        Ok(())
+    }
+
+    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+        try!(self.0.from_clause().collect_binds(out));
+        if let Some(clause) = self.0.where_clause() {
+            try!(clause.collect_binds(out));
         }
         Ok(())
     }

--- a/diesel/src/query_builder/distinct_clause.rs
+++ b/diesel/src/query_builder/distinct_clause.rs
@@ -1,5 +1,6 @@
 use backend::Backend;
 use query_builder::{QueryFragment, QueryBuilder, BuildQueryResult};
+use result::QueryResult;
 
 #[derive(Debug, Clone, Copy)]
 pub struct NoDistinctClause;
@@ -10,11 +11,19 @@ impl<DB: Backend> QueryFragment<DB> for NoDistinctClause {
     fn to_sql(&self, _out: &mut DB::QueryBuilder) -> BuildQueryResult {
         Ok(())
     }
+
+    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+        Ok(())
+    }
 }
 
 impl<DB: Backend> QueryFragment<DB> for DistinctClause {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_sql("DISTINCT ");
+        Ok(())
+    }
+
+    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -8,6 +8,7 @@ use std::marker::PhantomData;
 use backend::Backend;
 use expression::*;
 use query_source::*;
+use result::QueryResult;
 use super::distinct_clause::NoDistinctClause;
 use super::group_by_clause::NoGroupByClause;
 use super::limit_clause::NoLimitClause;
@@ -163,6 +164,18 @@ impl<ST, S, F, D, W, O, L, Of, G, DB> QueryFragment<DB>
         try!(self.offset.to_sql(out));
         Ok(())
     }
+
+    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+        try!(self.distinct.collect_binds(out));
+        try!(self.select.collect_binds(out));
+        try!(self.from.from_clause().collect_binds(out));
+        try!(self.where_clause.collect_binds(out));
+        try!(self.group_by.collect_binds(out));
+        try!(self.order.collect_binds(out));
+        try!(self.limit.collect_binds(out));
+        try!(self.offset.collect_binds(out));
+        Ok(())
+    }
 }
 
 impl<ST, S, D, W, O, L, Of, G, DB> QueryFragment<DB>
@@ -185,6 +198,17 @@ impl<ST, S, D, W, O, L, Of, G, DB> QueryFragment<DB>
         try!(self.order.to_sql(out));
         try!(self.limit.to_sql(out));
         try!(self.offset.to_sql(out));
+        Ok(())
+    }
+
+    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+        try!(self.distinct.collect_binds(out));
+        try!(self.select.collect_binds(out));
+        try!(self.where_clause.collect_binds(out));
+        try!(self.group_by.collect_binds(out));
+        try!(self.order.collect_binds(out));
+        try!(self.limit.collect_binds(out));
+        try!(self.offset.collect_binds(out));
         Ok(())
     }
 }

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -2,6 +2,7 @@ use backend::Backend;
 use expression::*;
 use expression::expression_methods::*;
 use expression::predicates::And;
+use result::QueryResult;
 use super::{QueryFragment, QueryBuilder, BuildQueryResult};
 use types::Bool;
 
@@ -16,6 +17,10 @@ pub struct NoWhereClause;
 
 impl<DB: Backend> QueryFragment<DB> for NoWhereClause {
     fn to_sql(&self, _out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        Ok(())
+    }
+
+    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -46,6 +51,10 @@ impl<DB, Expr> QueryFragment<DB> for WhereClause<Expr> where
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_sql(" WHERE ");
         self.0.to_sql(out)
+    }
+
+    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+        self.0.collect_binds(out)
     }
 }
 

--- a/diesel/src/query_dsl/with_dsl.rs
+++ b/diesel/src/query_dsl/with_dsl.rs
@@ -2,6 +2,7 @@ use expression::Expression;
 use expression::aliased::Aliased;
 use query_builder::*;
 use query_source::QuerySource;
+use result::QueryResult;
 
 /// Adds an additional expression to the FROM clause. This is useful for things
 /// like full text search, where you need to access the result of an expensive
@@ -63,6 +64,10 @@ impl<T: QueryFragment<Pg>> QueryFragment<Pg> for PgOnly<T> {
     fn to_sql(&self, out: &mut PgQueryBuilder) -> BuildQueryResult {
         self.0.to_sql(out)
     }
+
+    fn collect_binds(&self, out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+        self.0.collect_binds(out)
+    }
 }
 
 use backend::*;
@@ -70,5 +75,9 @@ use backend::*;
 impl<T: QueryFragment<Debug>> QueryFragment<Debug> for PgOnly<T> {
     fn to_sql(&self, out: &mut <Debug as Backend>::QueryBuilder) -> BuildQueryResult {
         self.0.to_sql(out)
+    }
+
+    fn collect_binds(&self, out: &mut <Debug as Backend>::BindCollector) -> QueryResult<()> {
+        self.0.collect_binds(out)
     }
 }

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -1,6 +1,7 @@
-use super::{QuerySource, Table};
-use query_builder::*;
 use expression::SelectableExpression;
+use query_builder::*;
+use result::QueryResult;
+use super::{QuerySource, Table};
 use types::IntoNullable;
 
 #[derive(Debug, Clone, Copy)]
@@ -119,6 +120,10 @@ impl<DB: Backend> QueryFragment<DB> for Inner {
         out.push_sql(" INNER");
         Ok(())
     }
+
+    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+        Ok(())
+    }
 }
 
 #[doc(hidden)]
@@ -128,6 +133,10 @@ pub struct LeftOuter;
 impl<DB: Backend> QueryFragment<DB> for LeftOuter {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_sql(" LEFT OUTER");
+        Ok(())
+    }
+
+    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -13,6 +13,7 @@ pub enum Error {
     NotFound,
     QueryBuilderError(Box<StdError+Send+Sync>),
     DeserializationError(Box<StdError+Send+Sync>),
+    SerializationError(Box<StdError+Send+Sync>),
     #[doc(hidden)]
     __Nonexhaustive,
 }
@@ -82,6 +83,7 @@ impl Display for Error {
             &Error::NotFound => f.write_str("NotFound"),
             &Error::QueryBuilderError(ref e) => e.fmt(f),
             &Error::DeserializationError(ref e) => e.fmt(f),
+            &Error::SerializationError(ref e) => e.fmt(f),
             &Error::__Nonexhaustive => unreachable!(),
         }
     }
@@ -95,6 +97,7 @@ impl StdError for Error {
             &Error::NotFound => "Record not found",
             &Error::QueryBuilderError(ref e) => e.description(),
             &Error::DeserializationError(ref e) => e.description(),
+            &Error::SerializationError(ref e) => e.description(),
             &Error::__Nonexhaustive => unreachable!(),
         }
     }

--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -1,4 +1,5 @@
 use backend::*;
+use query_builder::bind_collector::RawBytesBindCollector;
 use super::connection::SqliteValue;
 use super::query_builder::SqliteQueryBuilder;
 
@@ -16,6 +17,7 @@ pub enum SqliteType {
 
 impl Backend for Sqlite {
     type QueryBuilder = SqliteQueryBuilder;
+    type BindCollector = RawBytesBindCollector<Sqlite>;
     type RawValue = SqliteValue;
 }
 

--- a/diesel/src/sqlite/query_builder.rs
+++ b/diesel/src/sqlite/query_builder.rs
@@ -1,17 +1,14 @@
-use super::backend::{Sqlite, SqliteType};
+use super::backend::Sqlite;
 use query_builder::{QueryBuilder, BuildQueryResult};
-use types::HasSqlType;
 
 pub struct SqliteQueryBuilder {
     pub sql: String,
-    pub bind_params: Vec<(SqliteType, Option<Vec<u8>>)>,
 }
 
 impl SqliteQueryBuilder {
     pub fn new() -> Self {
         SqliteQueryBuilder {
             sql: String::new(),
-            bind_params: Vec::new(),
         }
     }
 }
@@ -28,10 +25,7 @@ impl QueryBuilder<Sqlite> for SqliteQueryBuilder {
         Ok(())
     }
 
-    fn push_bound_value<T>(&mut self, bind: Option<Vec<u8>>) where
-        Sqlite: HasSqlType<T>,
-    {
+    fn push_bind_param(&mut self) {
         self.push_sql("?");
-        self.bind_params.push((Sqlite::metadata(), bind));
     }
 }

--- a/diesel_compile_tests/tests/compile-fail/batch_insert_is_not_supported_on_sqlite.rs
+++ b/diesel_compile_tests/tests/compile-fail/batch_insert_is_not_supported_on_sqlite.rs
@@ -2,6 +2,7 @@
 extern crate diesel;
 
 use diesel::*;
+use diesel::backend::Backend;
 use diesel::sqlite::*;
 use diesel::types::{Integer, VarChar};
 
@@ -26,6 +27,10 @@ impl InsertValues<Sqlite> for MyValues {
     }
 
     fn values_clause(&self, out: &mut SqliteQueryBuilder) -> BuildQueryResult {
+        Ok(())
+    }
+
+    fn values_bind_params(&self, out: &mut <Sqlite as Backend>::BindCollector) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel_compile_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -49,6 +49,10 @@ impl InsertValues<Sqlite> for MyValues {
     fn values_clause(&self, out: &mut SqliteQueryBuilder) -> BuildQueryResult {
         Ok(())
     }
+
+    fn values_bind_params(&self, out: &mut <Sqlite as Backend>::BindCollector) -> QueryResult<()> {
+        Ok(())
+    }
 }
 
 impl<'a> Insertable<users::table, Sqlite> for &'a NewUser {

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -102,6 +102,10 @@ impl<T, DB> QueryFragment<DB> for Arbitrary<T> where
     fn to_sql(&self, _out: &mut DB::QueryBuilder) -> BuildQueryResult {
         Ok(())
     }
+
+    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+        Ok(())
+    }
 }
 
 impl<T, QS> SelectableExpression<QS> for Arbitrary<T> {}


### PR DESCRIPTION
This is primarily a structural change, separated out from some larger changes that I'd like to make. However, I wanted to keep the PR size reasonable.

This separates out construction of bind parameters from the construction of the SQL. This will ease implementation of prepared statement caching, and will be required for any implementation that uses the type identifier instead of constructing the SQL.

This will also enable future refactorings to bring `ToSql` closer to the actual process occurring, letting us eliminate the hacky code we have in SQLite right now, and lower the number of allocations for all backends.

Finally, this will all potentially enable us to actually show the values of the bind params in the debug query builder as long as the value of the bind param is `Debug`.

The bind param collector is generic over the backend because I plan to use a different struct for SQLite (which will eventually have a different interface). Additionally, the signature is `QueryResult<()>` instead of our usual `Box<Error>` because my eventual intention is to have the sqlite3 bind methods get called in this same function, which can fail in ways that we'd like to represent.

I do expect that the `RawBytesBindCollector` will be useable for every type except for SQLite, and have structured it so that code can be shared by other backends in the future

Walking the AST twice does not introduce any performance regressions, as the actual cost of this gets eliminated by monomorphisation and inlining. In fact, our benchmarks actually show a moderate improvement with this change. It's possible that the removal of the bind param lines from the query construction is allowing the optimizer to better operate on `to_sql`.

Through implementing this, `Changeset` and `InsertValues` stood out to me as places where I'd like to remove the "special `to_sql`". I explored this, but once again ran into the fact that if I had them return a `QueryFragment`, it wouldn't work as the type needs to change conditionally for both of those. I will continue to explore potential improvements in the future, as I didn't like that those had to change as a result of the signature of a (semi-)unrelated trait changing.