### PR TITLE
Add the `escape` method to `Like` and `NotLike`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## Unreleased
+
+### Added
+
+* Added the `escape` method to `Like` and `NotLike`, to specify the escape
+  character used in the pattern. See [EscapeExpressionMethods][escape] for
+  details.
+
+[escape]: http://docs.diesel.rs/diesel/expression/expression_methods/escape_expression_methods/trait.EscapeExpressionMethods.html
+
 ## [0.6.0] 2016-04-12
 
 ### Added

--- a/diesel/src/expression/expression_methods/escape_expression_methods.rs
+++ b/diesel/src/expression/expression_methods/escape_expression_methods.rs
@@ -1,0 +1,50 @@
+use expression::AsExpression;
+use expression::helper_types::AsExprOf;
+use expression::predicates::{Escape, Like, NotLike};
+use types::VarChar;
+/// Adds the `escape` method to `LIKE` and `NOT LIKE`. This is used to specify
+/// the escape character for the pattern.
+///
+/// # Example
+///
+/// ```rust
+/// # #[macro_use] extern crate diesel;
+/// # include!("src/doctest_setup.rs");
+/// #
+/// # table! {
+/// #     users {
+/// #         id -> Integer,
+/// #         name -> VarChar,
+/// #     }
+/// # }
+/// #
+/// # fn main() {
+/// #     use self::users::dsl::*;
+/// #     use diesel::insert;
+/// #     let connection = establish_connection();
+/// #     insert(&NewUser { name: "Ha%%0r".into() }).into(users)
+/// #         .execute(&connection).unwrap();
+/// let users_with_percent = users.select(name)
+///     .filter(name.like("%😀%%").escape('😀'))
+///     .load(&connection);
+/// let users_without_percent = users.select(name)
+///     .filter(name.not_like("%a%%").escape('a'))
+///     .load(&connection);
+/// assert_eq!(Ok(vec![String::from("Ha%%0r")]), users_with_percent);
+/// assert_eq!(Ok(vec![String::from("Sean"), String::from("Tess")]), users_without_percent);
+/// # }
+/// ```
+pub trait EscapeExpressionMethods: Sized {
+    fn escape(self, character: char) -> Escape<Self, AsExprOf<String, VarChar>> {
+        Escape::new(
+            self,
+            AsExpression::<VarChar>::as_expression(character.to_string()),
+        )
+    }
+}
+
+impl<T, U> EscapeExpressionMethods for Like<T, U> {
+}
+
+impl<T, U> EscapeExpressionMethods for NotLike<T, U> {
+}

--- a/diesel/src/expression/expression_methods/mod.rs
+++ b/diesel/src/expression/expression_methods/mod.rs
@@ -4,12 +4,14 @@
 //! You can rely on the methods provided by this trait existing on any
 //! `Expression` of the appropriate type. You should not rely on the specific
 //! traits existing, their names, or their organization.
-pub mod global_expression_methods;
 pub mod bool_expression_methods;
+pub mod escape_expression_methods;
+pub mod global_expression_methods;
 pub mod text_expression_methods;
 
-pub use self::global_expression_methods::ExpressionMethods;
 pub use self::bool_expression_methods::BoolExpressionMethods;
+pub use self::escape_expression_methods::EscapeExpressionMethods;
+pub use self::global_expression_methods::ExpressionMethods;
 pub use self::text_expression_methods::{TextExpressionMethods, VarCharExpressionMethods};
 
 #[cfg(feature = "postgres")]

--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -4,9 +4,8 @@
 use super::{Expression, AsExpression};
 use types;
 
-pub type AsExpr<Item, TargetExpr> = <Item as AsExpression<
-    <TargetExpr as Expression>::SqlType
->>::Expression;
+pub type AsExpr<Item, TargetExpr> = AsExprOf<Item, <TargetExpr as Expression>::SqlType>;
+pub type AsExprOf<Item, Type> = <Item as AsExpression<Type>>::Expression;
 
 macro_rules! gen_helper_type {
     ($name:ident) => {

--- a/diesel/src/expression/predicates.rs
+++ b/diesel/src/expression/predicates.rs
@@ -190,6 +190,7 @@ macro_rules! postfix_expression {
 
 infix_predicate!(And, " AND ");
 infix_predicate!(Between, " BETWEEN ");
+infix_predicate!(Escape, " ESCAPE ");
 infix_predicate!(Eq, " = ");
 infix_predicate!(Gt, " > ");
 infix_predicate!(GtEq, " >= ");


### PR DESCRIPTION
This is functionality I need to fix a bug in diesel_codegen related to
`infer_schema!` on SQLite. It felt appropriate to expose to the public
API. `name.like("foo\\%").escape('\')` will generate `name LIKE 'foo\%'
ESCAPE '\'` (with identifiers quoted and bind params for the strings).

While `ESCAPE` isn't part of the ANSI standard, it appears to be
supported by every backend, so I've left it unconstrained.