### PR TITLE
Make diesel_codegen 0.6 depend on diesel 0.6.

### DIFF
--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel_codegen"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
@@ -17,7 +17,7 @@ syntex_syntax = { version = "0.31.0", optional = true }
 [dependencies]
 syntex = { version = "0.31.0", optional = true }
 syntex_syntax = { version = "0.31.0", optional = true }
-diesel = { version = "0.5.0", default-features = false }
+diesel = { version = "0.6.0", default-features = false }
 
 [features]
 default = ["with-syntex", "postgres"]


### PR DESCRIPTION
Fixes #273. I don't think this is a breaking change, since codegen doesn't export any types from diesel that are used at runtime.

This allows `infer_schema!` to work with `bytea` columns at the least, and might fix other issues.