### PR TITLE
Allow migrations to be embedded in the resulting binary

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -e
 
-if [ "$1" == "integration" ]; then
+if [ "$1" == "integration" ] && [ "$2" == "sqlite" ]; then
+  (cd diesel_tests && DATABASE_URL=/tmp/test.db cargo test --features "unstable sqlite" --no-default-features)
+elif [ "$1" == "integration" ]; then
   (cd diesel_tests && cargo test --features "unstable postgres" --no-default-features)
 elif [ "$1" == "compile" ]; then
   (cd diesel_compile_tests && cargo test)

--- a/diesel/src/migrations/migration.rs
+++ b/diesel/src/migrations/migration.rs
@@ -33,11 +33,10 @@ fn file_names(path: &Path) -> Result<Vec<String>, MigrationError> {
     }).collect()
 }
 
-fn version_from_path(path: &Path) -> Result<String, MigrationError> {
+#[doc(hidden)]
+pub fn version_from_path(path: &Path) -> Result<String, MigrationError> {
     path.file_name().unwrap()
-        .to_os_string()
-        .into_string()
-        .unwrap()
+        .to_string_lossy()
         .split("_")
         .nth(0)
         .map(|s| Ok(s.into()))

--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -19,6 +19,9 @@ syntex = { version = "0.31.0", optional = true }
 syntex_syntax = { version = "0.31.0", optional = true }
 diesel = { version = "0.6.0", default-features = false }
 
+[dev-dependencies]
+tempdir = "0.3.4"
+
 [features]
 default = ["with-syntex", "postgres"]
 nightly = []

--- a/diesel_codegen/README.md
+++ b/diesel_codegen/README.md
@@ -154,3 +154,20 @@ crates, and having any columns with a type not already supported will result in
 a compiler error (please open an issue if this happens unexpectedly for a type
 listed in [our
 docs](http://sgrif.github.io/diesel/diesel/types/index.html#structs).)
+
+### `embed_migrations!()`
+
+This macro will read your migrations at compile time, and embed a module you can
+use to execute them at runtime without the migration files being present on the
+file system. This is useful if you would like to use Diesel's migration
+infrastructure, but want to ship a single executable file (such as for embedded
+applications). It can also be used to apply migrations to an in memory database
+(Diesel does this for its own test suite).
+
+You can optionally pass the path to the migrations directory to this macro. When
+left unspecified, Diesel Codegen will search for the migrations directory in the
+same way that Diesel CLI does. If specified, the path should be relative to the
+directory where the macro was invoked (similar to
+[`include_str!`][include-str]).
+
+[include-str]: https://doc.rust-lang.org/nightly/std/macro.include_str!.html

--- a/diesel_codegen/src/lib.in.rs
+++ b/diesel_codegen/src/lib.in.rs
@@ -1,6 +1,7 @@
 mod associations;
 mod attr;
 mod insertable;
+mod migrations;
 mod model;
 mod queryable;
 mod schema_inference;

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -33,6 +33,7 @@ pub fn register(reg: &mut syntex::Registry) {
     reg.add_decorator("changeset_for", update::expand_changeset_for);
     reg.add_decorator("has_many", associations::expand_has_many);
     reg.add_decorator("belongs_to", associations::expand_belongs_to);
+    reg.add_macro("embed_migrations", migrations::expand_embed_migrations);
     reg.add_macro("infer_table_from_schema", schema_inference::expand_load_table);
     reg.add_macro("infer_schema", schema_inference::expand_infer_schema);
 
@@ -64,6 +65,7 @@ pub fn register(reg: &mut rustc_plugin::Registry) {
         intern("belongs_to"),
         MultiDecorator(Box::new(associations::expand_belongs_to))
     );
+    reg.register_macro("embed_migrations", migrations::expand_embed_migrations);
     reg.register_macro("infer_table_from_schema", schema_inference::expand_load_table);
     reg.register_macro("infer_schema", schema_inference::expand_infer_schema);
 }

--- a/diesel_codegen/src/migrations.rs
+++ b/diesel_codegen/src/migrations.rs
@@ -1,0 +1,189 @@
+use diesel::migrations::search_for_migrations_directory;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use syntax::ast;
+use syntax::codemap::Span;
+use syntax::ext::base::*;
+use syntax::util::small_vector::SmallVector;
+use syntax::ptr::P;
+use syntax::ext::build::AstBuilder;
+
+pub fn expand_embed_migrations<'cx>(
+    cx: &'cx mut ExtCtxt,
+    sp: Span,
+    tts: &[ast::TokenTree]
+) -> Box<MacResult+'cx> {
+    let migrations_expr = migrations_directory_from_args(cx, sp, tts)
+        .and_then(|d| migration_literals_from_path(cx, sp, &d));
+    let migrations_expr = match migrations_expr {
+        Err(e) => {
+            cx.span_err(sp, &format!("Error reading migrations: {}", e));
+            return DummyResult::expr(sp);
+        }
+        Ok(v) => v,
+    };
+
+    let item = quote_item!(cx, mod embedded_migrations {
+        extern crate diesel;
+
+        use self::diesel::migrations::*;
+        use self::diesel::connection::SimpleConnection;
+        use std::io;
+
+        struct EmbeddedMigration {
+            version: &'static str,
+            up_sql: &'static str,
+        }
+
+        impl Migration for EmbeddedMigration {
+            fn version(&self) -> &str {
+                self.version
+            }
+
+            fn run(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
+                conn.batch_execute(self.up_sql).map_err(Into::into)
+            }
+
+            fn revert(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
+                unreachable!()
+            }
+        }
+
+        const ALL_MIGRATIONS: &'static [&'static Migration] = $migrations_expr;
+
+        pub fn run<C: MigrationConnection>(conn: &C) -> Result<(), RunMigrationsError> {
+            run_with_output(conn, &mut io::sink())
+        }
+
+        pub fn run_with_output<C: MigrationConnection>(conn: &C, out: &mut io::Write)
+            -> Result<(), RunMigrationsError>
+        {
+            run_migrations(conn, ALL_MIGRATIONS.iter().map(|v| *v), out)
+        }
+    }).unwrap();
+    MacEager::items(SmallVector::one(item))
+}
+
+fn migrations_directory_from_args(
+    cx: &mut ExtCtxt,
+    sp: Span,
+    tts: &[ast::TokenTree],
+) -> Result<PathBuf, Box<Error>> {
+    let callsite_file = cx.codemap().span_to_filename(sp);
+    let relative_path_to_migrations = if tts.is_empty() {
+        None
+    } else {
+        match get_single_str_from_tts(cx, sp, tts, "embed_migrations!") {
+            None => return Err("Usage error".into()),
+            value => value,
+        }
+    };
+    let callsite_path = Path::new(&callsite_file);
+    let migrations_path = relative_path_to_migrations.as_ref().map(Path::new);
+    resolve_migrations_directory(callsite_path, migrations_path)
+}
+
+fn resolve_migrations_directory(
+    callsite: &Path,
+    relative_path_to_migrations: Option<&Path>,
+) -> Result<PathBuf, Box<Error>> {
+    let callsite_dir = callsite.parent().unwrap();
+
+    let result = match relative_path_to_migrations {
+        Some(dir) => callsite_dir.join(dir),
+        None => try!(search_for_migrations_directory(&callsite_dir)),
+    };
+
+    result.canonicalize().map_err(Into::into)
+}
+
+fn migration_literals_from_path(
+    cx: &ExtCtxt,
+    sp: Span,
+    path: &Path,
+) -> Result<P<ast::Expr>, Box<Error>> {
+    use diesel::migrations::migration_paths_in_directory;
+
+    let exprs = try!(migration_paths_in_directory(&path)).into_iter()
+        .map(|e| migration_literal_from_path(cx, &e.path()))
+        .collect();
+    Ok(cx.expr_vec_slice(sp, try!(exprs)))
+}
+
+fn migration_literal_from_path(
+    cx: &ExtCtxt,
+    path: &Path,
+) -> Result<P<ast::Expr>, Box<Error>> {
+    use diesel::migrations::version_from_path;
+
+    let version = try!(version_from_path(path));
+    let sql_file = path.join("up.sql");
+    let sql_file_path = sql_file.to_string_lossy();
+
+    Ok(quote_expr!(cx, &EmbeddedMigration {
+        version: $version,
+        up_sql: include_str!($sql_file_path),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate tempdir;
+
+    use self::tempdir::TempDir;
+    use std::fs;
+    use std::path::Path;
+    use super::resolve_migrations_directory;
+
+    #[test]
+    fn migrations_directory_resolved_relative_to_callsite_dir() {
+        let tempdir = TempDir::new("diesel").unwrap();
+        fs::create_dir_all(tempdir.path().join("foo/special_migrations")).unwrap();
+        let callsite = tempdir.path().join("foo/bar.rs");
+        let relative_path = Some(Path::new("special_migrations"));
+
+        assert_eq!(
+            tempdir.path().join("foo/special_migrations").canonicalize().ok(),
+            resolve_migrations_directory(&callsite, relative_path).ok()
+        );
+    }
+
+    #[test]
+    fn migrations_directory_canonicalizes_result() {
+        let tempdir = TempDir::new("diesel").unwrap();
+        fs::create_dir_all(tempdir.path().join("foo/migrations/bar")).unwrap();
+        fs::create_dir_all(tempdir.path().join("foo/bar")).unwrap();
+        let callsite = tempdir.path().join("foo/bar/baz.rs");
+        let relative_path = Some(Path::new("../migrations/bar"));
+
+        assert_eq!(
+            tempdir.path().join("foo/migrations/bar").canonicalize().ok(),
+            resolve_migrations_directory(&callsite, relative_path).ok()
+        );
+    }
+
+    #[test]
+    fn migrations_directory_defaults_to_searching_migrations_path() {
+        let tempdir = TempDir::new("diesel").unwrap();
+        fs::create_dir_all(tempdir.path().join("foo/migrations")).unwrap();
+        fs::create_dir_all(tempdir.path().join("foo/bar")).unwrap();
+        let callsite = tempdir.path().join("foo/bar/baz.rs");
+
+        assert_eq!(
+            tempdir.path().join("foo/migrations").canonicalize().ok(),
+            resolve_migrations_directory(&callsite, None).ok()
+        );
+    }
+
+    #[test]
+    fn migrations_directory_allows_no_parent_dir_for_callsite() {
+        let tempdir = TempDir::new("diesel").unwrap();
+        fs::create_dir_all(tempdir.path().join("special_migrations")).unwrap();
+        let callsite = tempdir.path().join("bar.rs");
+        let relative_path = Some(Path::new("special_migrations"));
+        assert_eq!(
+            tempdir.path().join("special_migrations").canonicalize().ok(),
+            resolve_migrations_directory(&callsite, relative_path).ok()
+        );
+    }
+}

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -116,12 +116,12 @@ pub fn connection_without_transaction() -> TestConnection {
 }
 
 #[cfg(feature = "sqlite")]
-pub fn connection_without_transaction() -> TestConnection {
-    use std::io;
+embed_migrations!("../../migrations/sqlite");
 
+#[cfg(feature = "sqlite")]
+pub fn connection_without_transaction() -> TestConnection {
     let connection = ::diesel::sqlite::SqliteConnection::establish(":memory:").unwrap();
-    let migrations_dir = migrations::find_migrations_directory().unwrap().join("sqlite");
-    migrations::run_pending_migrations_in_directory(&connection, &migrations_dir, &mut io::sink()).unwrap();
+    embedded_migrations::run(&connection).unwrap();
     connection
 }
 


### PR DESCRIPTION
This is an alternate implementation of #199. That PR was on the
right track, and the work done so far is very much appreciated (and
provided some basis for this PR). However, the lack of tests,
documentation, and changelog entry as well as the remaining issues with
both implementation and code style ultimately meant it was just faster
to write out an implementation I was happier with.

The goal of this feature is to better enable usage of Diesel in embedded
applications. If you're distributing the binary to an environment you
don't control, you can't guarantee that the migrations will actually be
at the right location in the file system.

The `embed_migrations` macro will look for migrations in the directory
specified (or default to the same search CLI does if left unspecified),
read in the migration files, and exposes a module to allow you to run
them later. The embedded migrations are entirely constant, and won't
allocate when run any more than executing the SQL string directly would
have.

The generated code as it appears in our test suite can be found at
https://gist.github.com/sgrif/975bfd8418cde8766ab82ac001f1cd84

We do not read from `down.sql`, nor does the resulting struct store it,
as reverting a migration doesn't make sense for the use case that this
is targeting. Outside of development, you would always make a new
migration to change schema. The `unimplemented!()` would never result in
a runtime error, as the struct and constant are not public, and could
never be accessed other than through the `run` functions that we expose.

The generated module is private and called `embedded_migrations` for
considerations with anybody who is doing `use diesel::*` and/or `use
schema::*`. The idea is that this module would be generated close to
where it's being used. For those who do want a public module, it's quite
easy to write `pub use embedded_migrations as migrations`.

While this is redundant with our current "runtime" migration support
that exists in `run_pending_migrations`, I don't think it eliminates
their use case entirely. You can't use codegen to build a build script,
and I think automatically running migrations automatically in `build.rs`
makes complete sense, especially for tests, to ensure that the schema is
up to date before `infer_schema!` is evaluated. I could be convinced
that the CLI handles this enough, though.

Close #199