### PR TITLE
Add prepared statement caching for SQLite

### DIFF
--- a/diesel/src/expression/aliased.rs
+++ b/diesel/src/expression/aliased.rs
@@ -39,6 +39,10 @@ impl<'a, T, DB> QueryFragment<DB> for Aliased<'a, T> where
     fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
+    }
 }
 
 // FIXME This is incorrect, should only be selectable from WithQuerySource

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -55,6 +55,11 @@ impl<T, U, DB> QueryFragment<DB> for In<T, U> where
         try!(self.values.collect_binds(out));
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.left.is_safe_to_cache_prepared() &&
+            self.values.is_safe_to_cache_prepared()
+    }
 }
 
 use std::marker::PhantomData;
@@ -121,6 +126,10 @@ impl<T, DB> QueryFragment<DB> for Many<T> where
         }
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        false
+    }
 }
 
 pub struct Subselect<T, ST> {
@@ -148,5 +157,9 @@ impl<T, ST, DB> QueryFragment<DB> for Subselect<T, ST> where
 
     fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
         self.values.collect_binds(out)
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.values.is_safe_to_cache_prepared()
     }
 }

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -49,6 +49,10 @@ impl<T, U, DB> QueryFragment<DB> for Bound<T, U> where
             }
         }
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
+    }
 }
 
 impl<T, U, QS> SelectableExpression<QS> for Bound<T, U> where

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -68,6 +68,10 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Count<T> {
         try!(self.target.collect_binds(out));
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.target.is_safe_to_cache_prepared()
+    }
 }
 
 impl<T: Expression, QS> SelectableExpression<QS> for Count<T> {
@@ -89,6 +93,10 @@ impl<DB: Backend> QueryFragment<DB> for CountStar {
 
     fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
     }
 }
 

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -43,6 +43,10 @@ macro_rules! fold_function {
                 try!(self.target.collect_binds(out));
                 Ok(())
             }
+
+            fn is_safe_to_cache_prepared(&self) -> bool {
+                self.target.is_safe_to_cache_prepared()
+            }
         }
 
         impl<ST, T, QS> SelectableExpression<QS> for $type_name<T> where

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -40,6 +40,10 @@ macro_rules! ord_function {
                 try!(self.target.collect_binds(out));
                 Ok(())
             }
+
+            fn is_safe_to_cache_prepared(&self) -> bool {
+                self.target.is_safe_to_cache_prepared()
+            }
         }
 
         impl<T: Expression, QS> SelectableExpression<QS> for $type_name<T> {

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -28,6 +28,10 @@ impl<DB: Backend> QueryFragment<DB> for now {
     fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
+    }
 }
 
 operator_allowed!(now, Add, add);

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -52,6 +52,10 @@ macro_rules! sql_function_body {
                         &($(&self.$arg_name),*), out));
                 Ok(())
             }
+
+            fn is_safe_to_cache_prepared(&self) -> bool {
+                ($(&self.$arg_name),*).is_safe_to_cache_prepared()
+            }
         }
 
         #[allow(non_camel_case_types)]
@@ -151,6 +155,10 @@ macro_rules! no_arg_sql_function_body {
             fn collect_binds(&self, _out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
                 Ok(())
             }
+
+            fn is_safe_to_cache_prepared(&self) -> bool {
+                true
+            }
         }
     };
 
@@ -168,6 +176,10 @@ macro_rules! no_arg_sql_function_body {
 
             fn collect_binds(&self, _out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
                 Ok(())
+            }
+
+            fn is_safe_to_cache_prepared(&self) -> bool {
+                true
             }
         }
     };

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -21,6 +21,10 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Grouped<T> {
         try!(self.0.collect_binds(out));
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.0.is_safe_to_cache_prepared()
+    }
 }
 
 impl<T, QS> SelectableExpression<QS> for Grouped<T> where

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -30,6 +30,10 @@ impl<T, DB> QueryFragment<DB> for Nullable<T> where
     fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
         self.0.collect_binds(out)
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.0.is_safe_to_cache_prepared()
+    }
 }
 
 impl<T, QS> SelectableExpression<QS> for Nullable<T> where

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -44,6 +44,11 @@ macro_rules! numeric_operation {
                 try!(self.rhs.collect_binds(out));
                 Ok(())
             }
+
+            fn is_safe_to_cache_prepared(&self) -> bool {
+                self.lhs.is_safe_to_cache_prepared() &&
+                    self.rhs.is_safe_to_cache_prepared()
+            }
         }
 
         impl<Lhs, Rhs, QS> SelectableExpression<QS> for $name<Lhs, Rhs> where

--- a/diesel/src/expression/predicates.rs
+++ b/diesel/src/expression/predicates.rs
@@ -58,6 +58,11 @@ macro_rules! global_infix_predicate_to_sql {
                 try!(self.right.collect_binds(out));
                 Ok(())
             }
+
+            fn is_safe_to_cache_prepared(&self) -> bool {
+                self.left.is_safe_to_cache_prepared() &&
+                    self.right.is_safe_to_cache_prepared()
+            }
         }
     }
 }
@@ -86,6 +91,11 @@ macro_rules! backend_specific_infix_predicate_to_sql {
                 try!(self.right.collect_binds(out));
                 Ok(())
             }
+
+            fn is_safe_to_cache_prepared(&self) -> bool {
+                self.left.is_safe_to_cache_prepared() &&
+                    self.right.is_safe_to_cache_prepared()
+            }
         }
 
         impl<T, U> $crate::query_builder::QueryFragment<$crate::backend::Debug>
@@ -110,6 +120,11 @@ macro_rules! backend_specific_infix_predicate_to_sql {
                 try!(self.left.collect_binds(out));
                 try!(self.right.collect_binds(out));
                 Ok(())
+            }
+
+            fn is_safe_to_cache_prepared(&self) -> bool {
+                self.left.is_safe_to_cache_prepared() &&
+                    self.right.is_safe_to_cache_prepared()
             }
         }
     }
@@ -185,6 +200,10 @@ macro_rules! postfix_predicate_body {
             fn collect_binds(&self, out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
                 try!(self.expr.collect_binds(out));
                 Ok(())
+            }
+
+            fn is_safe_to_cache_prepared(&self) -> bool {
+                self.expr.is_safe_to_cache_prepared()
             }
         }
 

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -38,6 +38,10 @@ impl<ST, DB> QueryFragment<DB> for SqlLiteral<ST> where
     fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        false
+    }
 }
 
 impl<ST> Query for SqlLiteral<ST> {

--- a/diesel/src/macros.rs
+++ b/diesel/src/macros.rs
@@ -29,6 +29,10 @@ macro_rules! column {
             fn collect_binds(&self, _out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
                 Ok(())
             }
+
+            fn is_safe_to_cache_prepared(&self) -> bool {
+                true
+            }
         }
 
         impl $crate::expression::SelectableExpression<$($table)::*> for $column_name {}
@@ -262,6 +266,10 @@ macro_rules! table_body {
 
                     fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
                         Ok(())
+                    }
+
+                    fn is_safe_to_cache_prepared(&self) -> bool {
+                        true
                     }
                 }
 

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -81,6 +81,10 @@ impl<Expr, ST> QueryFragment<Pg> for Any<Expr, ST> where
         try!(self.expr.collect_binds(out));
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.expr.is_safe_to_cache_prepared()
+    }
 }
 
 impl<Expr, ST> QueryFragment<Debug> for Any<Expr, ST> where
@@ -96,6 +100,10 @@ impl<Expr, ST> QueryFragment<Debug> for Any<Expr, ST> where
     fn collect_binds(&self, out: &mut <Debug as Backend>::BindCollector) -> QueryResult<()> {
         try!(self.expr.collect_binds(out));
         Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.expr.is_safe_to_cache_prepared()
     }
 }
 

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -47,6 +47,11 @@ impl<Ts, Tz> QueryFragment<Pg> for AtTimeZone<Ts, Tz> where
         try!(self.timezone.collect_binds(out));
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.timestamp.is_safe_to_cache_prepared() &&
+            self.timezone.is_safe_to_cache_prepared()
+    }
 }
 
 impl<Ts, Tz> QueryFragment<Debug> for AtTimeZone<Ts, Tz> where
@@ -63,6 +68,11 @@ impl<Ts, Tz> QueryFragment<Debug> for AtTimeZone<Ts, Tz> where
         try!(self.timestamp.collect_binds(out));
         try!(self.timezone.collect_binds(out));
         Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.timestamp.is_safe_to_cache_prepared() &&
+            self.timezone.is_safe_to_cache_prepared()
     }
 }
 

--- a/diesel/src/query_builder/clause_macro.rs
+++ b/diesel/src/query_builder/clause_macro.rs
@@ -15,6 +15,10 @@ macro_rules! simple_clause {
             fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
                 Ok(())
             }
+
+            fn is_safe_to_cache_prepared(&self) -> bool {
+                true
+            }
         }
 
         #[derive(Debug, Clone, Copy)]
@@ -31,6 +35,10 @@ macro_rules! simple_clause {
 
             fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
                 self.0.collect_binds(out)
+            }
+
+            fn is_safe_to_cache_prepared(&self) -> bool {
+                self.0.is_safe_to_cache_prepared()
             }
         }
     }

--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -34,5 +34,10 @@ impl<T, DB> QueryFragment<DB> for DeleteStatement<T> where
         }
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.0.from_clause().is_safe_to_cache_prepared() &&
+            self.0.where_clause().map(|w| w.is_safe_to_cache_prepared()).unwrap_or(true)
+    }
 }
 

--- a/diesel/src/query_builder/distinct_clause.rs
+++ b/diesel/src/query_builder/distinct_clause.rs
@@ -15,6 +15,10 @@ impl<DB: Backend> QueryFragment<DB> for NoDistinctClause {
     fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
+    }
 }
 
 impl<DB: Backend> QueryFragment<DB> for DistinctClause {
@@ -25,5 +29,9 @@ impl<DB: Backend> QueryFragment<DB> for DistinctClause {
 
     fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
     }
 }

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -58,6 +58,10 @@ impl<T, U, DB> QueryFragment<DB> for InsertStatement<T, U> where
         try!(values.values_bind_params(out));
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        false
+    }
 }
 
 impl<T, U> AsQuery for InsertStatement<T, U> where
@@ -149,5 +153,9 @@ impl<T, U, DB> QueryFragment<DB> for InsertQuery<T, U> where
         try!(self.statement.collect_binds(out));
         try!(self.returning.collect_binds(out));
         Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        false
     }
 }

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -67,6 +67,7 @@ impl<'a, T: Query> Query for &'a T {
 pub trait QueryFragment<DB: Backend> {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult;
     fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()>;
+    fn is_safe_to_cache_prepared(&self) -> bool;
 }
 
 impl<T: ?Sized, DB> QueryFragment<DB> for Box<T> where
@@ -79,6 +80,10 @@ impl<T: ?Sized, DB> QueryFragment<DB> for Box<T> where
 
     fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
         QueryFragment::collect_binds(&**self, out)
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        QueryFragment::is_safe_to_cache_prepared(&**self)
     }
 }
 
@@ -93,6 +98,10 @@ impl<'a, T: ?Sized, DB> QueryFragment<DB> for &'a T where
     fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
         QueryFragment::collect_binds(&**self, out)
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        QueryFragment::is_safe_to_cache_prepared(&**self)
+    }
 }
 
 impl<DB: Backend> QueryFragment<DB> for () {
@@ -102,6 +111,10 @@ impl<DB: Backend> QueryFragment<DB> for () {
 
     fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
     }
 }
 

--- a/diesel/src/query_builder/nodes/mod.rs
+++ b/diesel/src/query_builder/nodes/mod.rs
@@ -12,6 +12,10 @@ impl<'a, DB: Backend> QueryFragment<DB> for Identifier<'a> {
     fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
+    }
 }
 
 pub struct Join<T, U, V, W> {
@@ -75,6 +79,13 @@ impl<T, U, V, W, DB> QueryFragment<DB> for Join<T, U, V, W> where
         try!(self.predicate.collect_binds(out));
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.lhs.is_safe_to_cache_prepared() &&
+            self.join_type.is_safe_to_cache_prepared() &&
+            self.rhs.is_safe_to_cache_prepared() &&
+            self.predicate.is_safe_to_cache_prepared()
+    }
 }
 
 pub struct InfixNode<'a, T, U> {
@@ -109,5 +120,10 @@ impl<'a, T, U, DB> QueryFragment<DB> for InfixNode<'a, T, U> where
         try!(self.lhs.collect_binds(out));
         try!(self.rhs.collect_binds(out));
         Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.lhs.is_safe_to_cache_prepared() &&
+            self.rhs.is_safe_to_cache_prepared()
     }
 }

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -95,6 +95,17 @@ impl<'a, ST, QS, DB> QueryFragment<DB> for BoxedSelectStatement<'a, ST, QS, DB> 
         try!(self.offset.collect_binds(out));
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.distinct.is_safe_to_cache_prepared() &&
+            self.select.is_safe_to_cache_prepared() &&
+            self.from.from_clause().is_safe_to_cache_prepared() &&
+            self.where_clause.as_ref().map(|w| w.is_safe_to_cache_prepared())
+                .unwrap_or(true) &&
+            self.order.is_safe_to_cache_prepared() &&
+            self.limit.is_safe_to_cache_prepared() &&
+            self.offset.is_safe_to_cache_prepared()
+    }
 }
 
 impl<'a, ST, QS, DB, Type, Selection> SelectDsl<Selection, Type>

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -176,6 +176,17 @@ impl<ST, S, F, D, W, O, L, Of, G, DB> QueryFragment<DB>
         try!(self.offset.collect_binds(out));
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.distinct.is_safe_to_cache_prepared() &&
+            self.select.is_safe_to_cache_prepared() &&
+            self.from.from_clause().is_safe_to_cache_prepared() &&
+            self.where_clause.is_safe_to_cache_prepared() &&
+            self.group_by.is_safe_to_cache_prepared() &&
+            self.order.is_safe_to_cache_prepared() &&
+            self.limit.is_safe_to_cache_prepared() &&
+            self.offset.is_safe_to_cache_prepared()
+    }
 }
 
 impl<ST, S, D, W, O, L, Of, G, DB> QueryFragment<DB>
@@ -210,6 +221,16 @@ impl<ST, S, D, W, O, L, Of, G, DB> QueryFragment<DB>
         try!(self.limit.collect_binds(out));
         try!(self.offset.collect_binds(out));
         Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.distinct.is_safe_to_cache_prepared() &&
+            self.select.is_safe_to_cache_prepared() &&
+            self.where_clause.is_safe_to_cache_prepared() &&
+            self.group_by.is_safe_to_cache_prepared() &&
+            self.order.is_safe_to_cache_prepared() &&
+            self.limit.is_safe_to_cache_prepared() &&
+            self.offset.is_safe_to_cache_prepared()
     }
 }
 

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -65,6 +65,10 @@ impl<T, U, DB> QueryFragment<DB> for UpdateStatement<T, U> where
         }
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        false
+    }
 }
 
 impl<T, U> AsQuery for UpdateStatement<T, U> where
@@ -152,5 +156,9 @@ impl<T, U, DB> QueryFragment<DB> for UpdateQuery<T, U> where
         try!(self.statement.collect_binds(out));
         try!(self.returning.collect_binds(out));
         Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        false
     }
 }

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -23,6 +23,10 @@ impl<DB: Backend> QueryFragment<DB> for NoWhereClause {
     fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
+    }
 }
 
 impl<Predicate> WhereAnd<Predicate> for NoWhereClause where
@@ -55,6 +59,10 @@ impl<DB, Expr> QueryFragment<DB> for WhereClause<Expr> where
 
     fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
         self.0.collect_binds(out)
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.0.is_safe_to_cache_prepared()
     }
 }
 

--- a/diesel/src/query_dsl/with_dsl.rs
+++ b/diesel/src/query_dsl/with_dsl.rs
@@ -68,6 +68,10 @@ impl<T: QueryFragment<Pg>> QueryFragment<Pg> for PgOnly<T> {
     fn collect_binds(&self, out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
         self.0.collect_binds(out)
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.0.is_safe_to_cache_prepared()
+    }
 }
 
 use backend::*;
@@ -79,5 +83,9 @@ impl<T: QueryFragment<Debug>> QueryFragment<Debug> for PgOnly<T> {
 
     fn collect_binds(&self, out: &mut <Debug as Backend>::BindCollector) -> QueryResult<()> {
         self.0.collect_binds(out)
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.0.is_safe_to_cache_prepared()
     }
 }

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -124,6 +124,10 @@ impl<DB: Backend> QueryFragment<DB> for Inner {
     fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
+    }
 }
 
 #[doc(hidden)]
@@ -138,5 +142,9 @@ impl<DB: Backend> QueryFragment<DB> for LeftOuter {
 
     fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
     }
 }

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -7,13 +7,13 @@ use sqlite::Sqlite;
 use super::stmt::Statement;
 use types::{HasSqlType, FromSqlRow};
 
-pub struct StatementIterator<ST, T> {
-    stmt: Statement,
+pub struct StatementIterator<'a, ST, T> {
+    stmt: &'a mut Statement,
     _marker: PhantomData<(ST, T)>,
 }
 
-impl<ST, T> StatementIterator<ST, T> {
-    pub fn new(stmt: Statement) -> Self {
+impl<'a, ST, T> StatementIterator<'a, ST, T> {
+    pub fn new(stmt: &'a mut Statement) -> Self {
         StatementIterator {
             stmt: stmt,
             _marker: PhantomData,
@@ -21,7 +21,7 @@ impl<ST, T> StatementIterator<ST, T> {
     }
 }
 
-impl<ST, T> Iterator for StatementIterator<ST, T> where
+impl<'a, ST, T> Iterator for StatementIterator<'a, ST, T> where
     Sqlite: HasSqlType<ST>,
     T: Queryable<ST, Sqlite>,
 {

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -93,6 +93,10 @@ macro_rules! tuple_impls {
                     )+
                     Ok(())
                 }
+
+                fn is_safe_to_cache_prepared(&self) -> bool {
+                    $(e!(self.$idx.is_safe_to_cache_prepared()) &&)+ true
+                }
             }
 
             impl<$($T: Expression + NonAggregate),+> NonAggregate for ($($T,)+) {

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -106,6 +106,10 @@ impl<T, DB> QueryFragment<DB> for Arbitrary<T> where
     fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
+    }
 }
 
 impl<T, QS> SelectableExpression<QS> for Arbitrary<T> {}

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -88,6 +88,10 @@ impl<'a, DB, Cols> QueryFragment<DB> for CreateTable<'a, Cols> where
         try!(self.columns.collect_binds(out));
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        false
+    }
 }
 
 impl<'a, DB, T> QueryFragment<DB> for Column<'a, T> where
@@ -102,6 +106,10 @@ impl<'a, DB, T> QueryFragment<DB> for Column<'a, T> where
 
     fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
         Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        false
     }
 }
 
@@ -119,6 +127,10 @@ impl<DB, Col> QueryFragment<DB> for PrimaryKey<Col> where
         try!(self.0.collect_binds(out));
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(feature = "sqlite")]
@@ -135,6 +147,10 @@ impl<Col> QueryFragment<Sqlite> for AutoIncrement<Col> where
         try!(self.0.collect_binds(out));
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(feature = "postgres")]
@@ -147,6 +163,10 @@ impl<'a> QueryFragment<Pg> for AutoIncrement<PrimaryKey<Column<'a, Integer>>> {
 
     fn collect_binds(&self, _out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
         Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        false
     }
 }
 
@@ -164,6 +184,10 @@ impl<DB, Col> QueryFragment<DB> for NotNull<Col> where
         try!(self.0.collect_binds(out));
         Ok(())
     }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        false
+    }
 }
 
 impl<'a, DB, Col> QueryFragment<DB> for Default<'a, Col> where
@@ -180,5 +204,9 @@ impl<'a, DB, Col> QueryFragment<DB> for Default<'a, Col> where
     fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
         try!(self.column.collect_binds(out));
         Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        false
     }
 }


### PR DESCRIPTION
This is the first pass at adding prepared statement caching to Diesel.
The query builder will still run, as we are using the SQL string as the
key. Eventually this will be replaced with a type identifier, but we're
not there yet.

Most of the groundwork is laid to apply this to PG as well, but to start
it only applies to SQLite. The cache is placed at the top of the struct
instead of the end to ensure that the statements are dropped before the
raw connection. I'm still trying to determine if the order that fields
are dropped is something we can rely on. We may need to come up with an
alternate implementation for that part of this.

The prepared statements are stored in a hash map, and not some sort of
LRU cache. This means that the memory growth here could be unbounded if
left unchecked. In practice though, there is an upper bound as long as
we exclude certain types of queries from the cache. In particular, we
need to exclude queries that can generate different SQL without the type
changing. Therefore, we apply the following rules:

- ASTs containing the `Many` node are not cached (`WHERE foo IN (?, ?,
  ?)` type queries)
- ASTs containing a `SqlLiteral` node are not cached
- Insert statements are not cached
- Update statements are not cached

There's an argument for allowing `SqlLiteral` nodes to be cached, but I
am erring on the side of caution here. We can't tell if you're
dynamically generating the SQL in that node or not, and allowing them to
be cached would require exposing controls to care about internals that I
want to keep internal for the time being.

This results in a healthy performance improvement across the board.

Before
------

```
test bench_selecting_0_rows_with_medium_complex_query         ... bench:      43,125 ns/iter (+/- 12,545)
test bench_selecting_0_rows_with_trivial_query                ... bench:       5,755 ns/iter (+/- 2,063)
test bench_selecting_10k_rows_with_medium_complex_query       ... bench:  22,090,236 ns/iter (+/- 7,078,394)
test bench_selecting_10k_rows_with_medium_complex_query_boxed ... bench:  20,322,178 ns/iter (+/- 5,829,031)
test bench_selecting_10k_rows_with_trivial_query              ... bench:   2,980,795 ns/iter (+/- 1,046,410)
test bench_selecting_10k_rows_with_trivial_query_boxed        ... bench:   2,894,526 ns/iter (+/- 829,044)
```

After
-----

```
test bench_selecting_0_rows_with_medium_complex_query         ... bench:      16,414 ns/iter (+/- 4,357)
test bench_selecting_0_rows_with_trivial_query                ... bench:       1,187 ns/iter (+/- 296)
test bench_selecting_10k_rows_with_medium_complex_query       ... bench:  19,490,094 ns/iter (+/- 4,403,771)
test bench_selecting_10k_rows_with_medium_complex_query_boxed ... bench:  18,980,924 ns/iter (+/- 3,537,891)
test bench_selecting_10k_rows_with_trivial_query              ... bench:   2,873,268 ns/iter (+/- 1,174,266)
test bench_selecting_10k_rows_with_trivial_query_boxed        ... bench:   2,891,690 ns/iter (+/- 1,012,551)
```

We can probably structure this a little bit more "unsafely" to eliminate
the overhead of `Rc` and `RefCell`. A statement will never have more
than one reference at a time (and this is enforced by `RefCell`, since
basically every method on `Statement` requires `&mut self`). We could in
theory just "copy" the `Statement` struct instead. The code is
encapsulated to allow this, but the overhead of `Rc<RefCell<>>` isn't
high enough to justify it.